### PR TITLE
Fix broadcast timing

### DIFF
--- a/motep/loss.py
+++ b/motep/loss.py
@@ -469,7 +469,6 @@ class ErrorPrinter:
             Errors.
 
         """
-        self.loss.broadcast()  # be sure that all processes has the same data
         errors = self.calculate()
 
         key0 = "energy"

--- a/motep/trainer.py
+++ b/motep/trainer.py
@@ -74,6 +74,7 @@ def train(filename_setting: str, comm: MPI.Comm) -> None:
             # Instantiate an `Optimizer` class
             optimizer: OptimizerBase = make_optimizer(step["method"])(loss, **step)
             optimizer.optimize(**step.get("kwargs", {}))
+            loss.broadcast()  # be sure that all processes have the same data
             if rank == 0:
                 print(flush=True)
 


### PR DESCRIPTION
This PR fixes the timing of data broadcasting.

Before `bcast` is called in `ErrorPrinter`, which is called only for `rank == 0`, which probably caused an error.
This issue is fixed in this PR by moving `bcast` out of the if-block for error printing.