### PR TITLE
Add tests in GitHub actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
+          python -m pip install jax
           python -m pip install pytest
           python -m pip install .
       - name: Run pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
+          python -m pip install numba
           python -m pip install jax
           python -m pip install pytest
           python -m pip install .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,4 +29,5 @@ jobs:
           python -m pip install .
       - name: Run pytest
         run: |
-          python -m pytest
+          # python -m pytest -v
+          python -m pytest -v tests/test_mtp.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: mpi4py/setup-mpi@v1
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+    branches:
+    - '*'
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pip install .
+      - name: Run pytest
+        run: |
+          python -m pytest


### PR DESCRIPTION
This PR adds tests in GitHub actions.

With this, at every PR, we can, in principle, check how the code is stable.

There are two issues remaining, yet I think we can first merge the PR to anyway enable the auto-testing.

(1) Presently, tests take too long time. To first demonstrate how Github actions work, I so far only test `tests/test_mtp.py`.

(2) So far I observed [JAX related errors as found in my forked repo](https://github.com/yuzie007/motep/actions/runs/16438387828/job/46453123410). I will open a separate issue for this.