### PR TITLE
Fix float format in `write_cfg`

### DIFF
--- a/motep/io/mlip/cfg.py
+++ b/motep/io/mlip/cfg.py
@@ -253,15 +253,15 @@ def _write_atom_data(file: TextIO, atoms: Atoms, species: list[int]) -> None:
     if "forces" in atoms.calc.results:
         forces = atoms.calc.results["forces"]
     for i, number in enumerate(numbers):
-        file.write(f"{i + 1:14d}")
-        file.write(f"{species.index(number):5d}")
+        file.write(f"    {i + 1:10d}")
+        file.write(f" {species.index(number):4d}")
         file.write(" ")
         for j in range(3):
-            file.write(f"{positions[i, j]:14.6f}")
+            file.write(f" {positions[i, j]:13.6f}")
         if "forces" in atoms.calc.results:
             file.write(" ")
             for j in range(3):
-                file.write(f"{forces[i, j]:12.6f}")
+                file.write(f" {forces[i, j]:11.6f}")
         file.write("\n")
 
 


### PR DESCRIPTION
When the potential is not well fitted to a target system, forces can be extremely large.
With the present `write_cfg`, then, there are no spaces between force columns, resulting in the failure of re-parsing with `read_cfg`.
The present PR fixes this.
The format specification is now made exactly consistent with the MLIP-2 code.