### PR TITLE
Solve issue #18

### DIFF
--- a/motep/optimizers/scipy.py
+++ b/motep/optimizers/scipy.py
@@ -99,16 +99,14 @@ class ScipyMinimizeOptimizer(ScipyOptimizerBase):
             if "scaling" in self.optimized:
                 raise ValueError("`jac` cannot (so far) be used to optimize `scaling`.")
             kwargs["jac"] = self.loss.jac
-        if kwargs["method"].lower() not in {
-            "nelder-mead",
-            "powell",
-            "l-bfgs-b",
-            "cobyla",
-            "cobyqa",
-            "slsqp",
-            "tnc",
-            "trust-constr",
-            "_custom",
+        if kwargs.get("method", "").lower() in {
+            "cg",
+            "bfgs",
+            "newton-cg",
+            "dogleg",
+            "trust-ncg",
+            "trust-exact",
+            "trust-krylov",
         }:
             bounds = None
         callback = Callback(self.loss)

--- a/motep/setting.py
+++ b/motep/setting.py
@@ -82,7 +82,7 @@ class TrainSetting(Setting):
     loss: LossSetting = field(default_factory=LossSetting)
     steps: list[dict] = field(
         default_factory=lambda: [
-            {"method": "L-BFGS-B", "optimized": ["radial_coeffs", "moment_coeffs"]},
+            {"method": "minimize", "optimized": ["radial_coeffs", "moment_coeffs"]},
         ],
     )
 

--- a/motep/setting.py
+++ b/motep/setting.py
@@ -6,23 +6,7 @@ import pathlib
 import tomllib
 from dataclasses import dataclass, field
 
-scipy_minimize_methods = {
-    "nelder-mead",
-    "powell",
-    "cg",
-    "bfgs",
-    "newton-cg",
-    "l-bfgs-b",
-    "tnc",
-    "cobyla",
-    "cobyqa",
-    "slsqp",
-    "trust-constr",
-    "dogleg",
-    "trust-ncg",
-    "trust-exact",
-    "trust-krylov",
-}
+from scipy.optimize._minimize import MINIMIZE_METHODS  # noqa: PLC2701
 
 
 @dataclass
@@ -67,7 +51,7 @@ def _convert_steps(steps: list[dict]) -> list[dict]:
     for i, value in enumerate(steps):
         if not isinstance(value, dict):
             steps["steps"][i] = {"method": value}
-        if value["method"].lower() in scipy_minimize_methods:
+        if value["method"].lower() in MINIMIZE_METHODS:
             if "kwargs" not in value:
                 value["kwargs"] = {}
             value["kwargs"]["method"] = value["method"]
@@ -82,7 +66,7 @@ class TrainSetting(Setting):
     loss: LossSetting = field(default_factory=LossSetting)
     steps: list[dict] = field(
         default_factory=lambda: [
-            {"method": "minimize", "optimized": ["radial_coeffs", "moment_coeffs"]},
+            {"method": "minimize"},
         ],
     )
 

--- a/tests/optimizers/test_scipy.py
+++ b/tests/optimizers/test_scipy.py
@@ -12,7 +12,14 @@ from motep.io.mlip.mtp import read_mtp
 from motep.loss import LossFunction
 from motep.optimizers.scipy import ScipyMinimizeOptimizer
 from motep.potentials.mtp.data import MTPData
-from motep.setting import LossSetting
+from motep.setting import LossSetting, scipy_minimize_methods
+
+
+def test_scipy_methods_list() -> None:
+    """Test that the list of minmize methods is same as Scipy."""
+    from scipy.optimize._minimize import MINIMIZE_METHODS
+
+    assert set(MINIMIZE_METHODS) == set(scipy_minimize_methods)
 
 
 def make_crystals(

--- a/tests/optimizers/test_scipy.py
+++ b/tests/optimizers/test_scipy.py
@@ -12,14 +12,7 @@ from motep.io.mlip.mtp import read_mtp
 from motep.loss import LossFunction
 from motep.optimizers.scipy import ScipyMinimizeOptimizer
 from motep.potentials.mtp.data import MTPData
-from motep.setting import LossSetting, scipy_minimize_methods
-
-
-def test_scipy_methods_list() -> None:
-    """Test that the list of minmize methods is same as Scipy."""
-    from scipy.optimize._minimize import MINIMIZE_METHODS
-
-    assert set(MINIMIZE_METHODS) == set(scipy_minimize_methods)
+from motep.setting import LossSetting
 
 
 def make_crystals(


### PR DESCRIPTION
To solve issue #18 I now moved `_parse_steps` into `TrainSetting` to include the conversion also if `TrainSetting` is instantiated without parsing a toml file with `parse_setting`. I also thought this might be slightly more intuitive since `steps` is an attribute of `TrainSetting`. I also renamed it to `_convert_steps` to better distinguish it from `parse_setting`.

Regarding the discussion in issue #18, this is now a middle way between 1 and 2. I found it difficult to implement 2 in a nice way. The check now remains in `setting.py`, but allows the same "convenience" by calling TrainSetting as with the toml file from the command line. Still I changed the default to "minimize" and allowed `method` not to be specified in `ScipyMinimizeOptimizer.optimize` `kwargs` since it felt more natural to rely on Scipy minimize's own default.

I'd also like to remove the `optimized` keyword from the `TrainSetting` default, to reduce the number of different defaults, since the `ScipyOptimizerBase` has the default `["species_coeffs", "moment_coeffs", "radial_coeffs"]`.