### PR TITLE
Avoid parallel deadlocks

### DIFF
--- a/motep/io/__init__.py
+++ b/motep/io/__init__.py
@@ -51,7 +51,7 @@ def read(filename: str, species: list[int] | None = None) -> list[Atoms]:
     if isinstance(filename_parsed, str) and filename_parsed.endswith(".cfg"):
         images = read_cfg(filename_parsed, index=index, species=species)
     else:
-        images = ase.io.read(filename_parsed, index=index)
+        images = ase.io.read(filename_parsed, index=index, parallel=False)
     return [images] if isinstance(images, Atoms) else images
 
 

--- a/motep/optimizers/base.py
+++ b/motep/optimizers/base.py
@@ -11,8 +11,8 @@ class OptimizerBase(ABC):
 
     Attributes
     ----------
-    mtp_data : MTPData
-        :class:`motep.potentials.MTPData` object.
+    loss : LossFunction
+        :class:`motep.loss.LossFunction` object.
 
     """
 
@@ -25,6 +25,10 @@ class OptimizerBase(ABC):
             :class:`motep.loss.LossFunction` object.
         **kwargs : dict[str, Any]
             Options passed to the `Optimizer` class.
+
+        Raises
+        ------
+        ValueError
 
         """
         self.loss = loss
@@ -41,7 +45,7 @@ class OptimizerBase(ABC):
 
     @abstractmethod
     def optimize(self, **kwargs: dict[str, Any]) -> None:
-        """Optimize parameters."""
+        """Optimize the parameters of `self.loss.mtp_data`."""
 
     @property
     @abstractmethod

--- a/motep/optimizers/ideal.py
+++ b/motep/optimizers/ideal.py
@@ -25,6 +25,7 @@ class NoInteractionOptimizer(OptimizerBase):
 
         # Calculate basis functions of `loss.images`
         loss_value = self.loss(parameters)
+        self.loss.broadcast()
 
         # Print the value of the loss function.
         callback(OptimizeResult(x=parameters, fun=loss_value))

--- a/motep/optimizers/randomizer.py
+++ b/motep/optimizers/randomizer.py
@@ -33,6 +33,7 @@ class Randomizer(OptimizerBase):
 
         # Calculate basis functions of `loss.images`
         loss_value = self.loss(parameters)
+        self.loss.broadcast()
 
         # Print the value of the loss function.
         callback(OptimizeResult(x=parameters, fun=loss_value))

--- a/motep/optimizers/randomizer.py
+++ b/motep/optimizers/randomizer.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import numpy as np
+from scipy.optimize._optimize import OptimizeResult
 
 from motep.loss import LossFunctionBase
 from motep.optimizers.base import OptimizerBase
@@ -26,17 +27,15 @@ class Randomizer(OptimizerBase):
         self.optimized = optimized
 
     def optimize(self, **kwargs: dict[str, Any]) -> None:
-        """Randomize parameters."""
         parameters = self.loss.mtp_data.parameters
-
-        # Calculate basis functions of `fitness.images`
-        self.loss(parameters)
+        callback = Callback(self.loss)
         rng: np.random.Generator = self.loss.setting["rng"]
 
-        callback = Callback(self.loss)
+        # Calculate basis functions of `loss.images`
+        loss_value = self.loss(parameters)
 
         # Print the value of the loss function.
-        callback(parameters)
+        callback(OptimizeResult(x=parameters, fun=loss_value))
 
         mtp_data = self.loss.mtp_data
         for key in self.optimized:
@@ -44,10 +43,12 @@ class Randomizer(OptimizerBase):
             ub = +5.0
             shape = mtp_data[key].shape
             mtp_data[key] = rng.uniform(lb, ub, size=shape)
-
+        # Update `parameters` by calling the property
         parameters = mtp_data.parameters
 
-        # Print the value of the loss function.
-        callback(parameters)
+        # Evaluate loss with the new parameters
+        loss_value = self.loss(parameters)
+        self.loss.broadcast()
 
-        self.loss.mtp_data.parameters = parameters
+        # Print the value of the loss function.
+        callback(OptimizeResult(x=parameters, fun=loss_value))

--- a/motep/optimizers/scipy.py
+++ b/motep/optimizers/scipy.py
@@ -21,12 +21,8 @@ class Callback:
         self.loss = loss
         self.iter = 0
 
-    def __call__(self, intermediate_result: OptimizeResult | np.ndarray):
-        fun = (
-            intermediate_result.fun
-            if isinstance(intermediate_result, OptimizeResult)
-            else self.loss(intermediate_result)
-        )
+    def __call__(self, intermediate_result: OptimizeResult):
+        fun = intermediate_result.fun
         if self.loss.comm.Get_rank() == 0:
             print(f"loss {self.iter:4d}:", fun, flush=True)
         self.iter += 1


### PR DESCRIPTION
Background: There are two parallelization errors when
1. reading files through `read_images` with `ase.io.read` (parallel deadlock) and
2. optimizing with `LLS` or `Level2MTP` with "species_coefficients" (`calc.results` is empty)

Solutions:
1. is here resolved for the time being by adding `parallel=False` but should probably be part of a revision of parallel reading and writing at some point (see issue #21).
2. when `loss` is called in `Callback.__call__`, also `loss.broadcast` needs to be called afterwards. Suggested solution is to remove the possibility of calling `loss` in `Callback.__call__` and instead directly use the SciPy `OptimizeResult` class in the implemented optimizers. This also forces saving the `loss` evaluation result performed anyway, and saves time collecting the results again, which has some noticeable effect on performance (at least when the actual calculation time is small, i.e. low levels).