### PR TITLE
Fix `LLSOptimizerBase` for species_coeffs/forces

### DIFF
--- a/motep/optimizers/lls.py
+++ b/motep/optimizers/lls.py
@@ -50,11 +50,11 @@ class LLSOptimizerBase(OptimizerBase):
         if "energy" in self.minimized:
             v = self._calc_matrix_energies_species_coeffs()
             tmp.append(np.sqrt(setting.energy_weight) * v)
+        # `species_coeffs` do not affect forces and stresses,
+        # and therefore the corresponding sub-mattrices should be zero-filled.
         if "forces" in self.minimized:
-            shape = (
-                sum(atoms.calc.results["forces"].size for atoms in images),
-                len(species),
-            )
+            nforces = sum(atoms.calc.targets["forces"].size for atoms in images)
+            shape = (nforces, len(species))
             tmp.append(np.zeros(shape))
         if "stress" in self.minimized:
             shape = (9 * len(images), len(species))


### PR DESCRIPTION
The PR fixes the following error related to `LLSOptimizer`.
<details>

```
Traceback (most recent call last):
  File "/Users/ikeda/miniforge3/envs/myenv/bin/motep", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/ikeda/codes/motep/motep/__init__.py", line 34, in main
    commands[args.command].run(args)
  File "/Users/ikeda/codes/motep/motep/trainer.py", line 97, in run
    train(args.setting, comm)
  File "/Users/ikeda/codes/motep/motep/trainer.py", line 76, in train
    optimizer.optimize(**step.get("kwargs", {}))
  File "/Users/ikeda/codes/motep/motep/optimizers/lls.py", line 201, in optimize
    matrix = self._calc_matrix()
             ^^^^^^^^^^^^^^^^^^^
  File "/Users/ikeda/codes/motep/motep/optimizers/lls.py", line 223, in _calc_matrix
    tmp.append(self._calc_matrix_species_coeffs())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ikeda/codes/motep/motep/optimizers/lls.py", line 55, in _calc_matrix_species_coeffs
    sum(atoms.calc.results["forces"].size for atoms in images),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ikeda/codes/motep/motep/optimizers/lls.py", line 55, in <genexpr>
    sum(atoms.calc.results["forces"].size for atoms in images),
        ~~~~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'forces'
Traceback (most recent call last):
  File "/Users/ikeda/miniforge3/envs/myenv/bin/motep", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/ikeda/codes/motep/motep/__init__.py", line 34, in main
    commands[args.command].run(args)
  File "/Users/ikeda/codes/motep/motep/trainer.py", line 97, in run
    train(args.setting, comm)
  File "/Users/ikeda/codes/motep/motep/trainer.py", line 76, in train
    optimizer.optimize(**step.get("kwargs", {}))
  File "/Users/ikeda/codes/motep/motep/optimizers/lls.py", line 201, in optimize
    matrix = self._calc_matrix()
             ^^^^^^^^^^^^^^^^^^^
  File "/Users/ikeda/codes/motep/motep/optimizers/lls.py", line 223, in _calc_matrix
    tmp.append(self._calc_matrix_species_coeffs())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ikeda/codes/motep/motep/optimizers/lls.py", line 55, in _calc_matrix_species_coeffs
    sum(atoms.calc.results["forces"].size for atoms in images),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ikeda/codes/motep/motep/optimizers/lls.py", line 55, in <genexpr>
    sum(atoms.calc.results["forces"].size for atoms in images),
        ~~~~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'forces'
```
</details>

The cause of this error is a bit complex, and I still cannot fully track it, but the points are as follows.

- The error occurs when we have `forces` in `minimized` for `LLSOptimizer` and `species_coeffs` in `optimized`, and further we turn on MPI parallelization.
- The target properties in the training dataset is stored in `atoms.calc.targets`, while the predicted properties by the MTP is stored in `atoms.calc.results`. In the beginning of `LLSOptimizer`, `atoms.calc.results` should be empty. When `loss.__call__` is called, then the MTP predicted values are stored. In a parallel mode, the values should be broadcasted to the same objects in all the nodes, which is however not fully done in some part of `LLSOptimizer`.

The simple solution is to rely on `targets` rather than `results` when making a necessary matrix size, as now done in this PR.
Later we should better reorganize the parallelization strategy, which will be in a separate future PR.

In principle I should also have a test, but due to the complexity I could not think of a good one so far.
This will be also later.