### PR TITLE
Check species and save moment basis values in _calc_run

### DIFF
--- a/motep/potentials/mtp/base.py
+++ b/motep/potentials/mtp/base.py
@@ -213,11 +213,11 @@ class EngineBase:
             `_is_trained`).
 
         """
-        if len(set(atoms.numbers)) > self.mtp_data.species_count:
+        if np.unique(atoms.numbers).size > self.mtp_data.species_count:
             msg = "The number of species in input atoms is larger than species_count."
             raise ValueError(msg)
         if not self._is_trained:
-            unique_species = sorted(set(atoms.numbers))
+            unique_species = np.unique(atoms.numbers)
             if not all(_ in self.mtp_data.species for _ in unique_species):
                 msg = (
                     "All species in input atoms are not in mtp_data.species.\n"

--- a/motep/potentials/mtp/base.py
+++ b/motep/potentials/mtp/base.py
@@ -202,6 +202,30 @@ class EngineBase:
         all_r_ijs[self.all_js[:, :] < 0, :] = max_dist
         return self.all_js, all_r_ijs
 
+    def check_species(self, atoms: Atoms) -> None:
+        """Check if `atoms` comply with the `mtp_data.species`.
+
+        Raises
+        ------
+        ValueError
+            If the unique `atoms.numbers` is larger than `species_count`, or if
+            they are not present in `mtp_data.species` (only when not
+            `_is_trained`).
+
+        """
+        if len(set(atoms.numbers)) > self.mtp_data.species_count:
+            msg = "The number of species in input atoms is larger than species_count."
+            raise ValueError(msg)
+        if not self._is_trained:
+            unique_species = sorted(set(atoms.numbers))
+            if not all(_ in self.mtp_data.species for _ in unique_species):
+                msg = (
+                    "All species in input atoms are not in mtp_data.species.\n"
+                    f"  species in atoms: {unique_species}\n"
+                    f"  species in mtp_data: {self.mtp_data.species}"
+                )
+                raise ValueError(msg)
+
     @abstractmethod
     def _calculate(self, atoms: Atoms) -> tuple: ...
 
@@ -213,6 +237,7 @@ class EngineBase:
         Dictionary with energies, energy, forces and stress.
 
         """
+        self.check_species(atoms)
         self.update_neighbor_list(atoms)
 
         energies, forces, stress = self._calculate(atoms)

--- a/motep/potentials/mtp/numba/engine.py
+++ b/motep/potentials/mtp/numba/engine.py
@@ -44,6 +44,10 @@ class NumbaMTPEngine(EngineBase):
 
         itypes = get_types(atoms, mtp_data.species)
         all_jtypes = itypes[all_js]
+
+        self.mbd.clean()
+        self.rbd.clean()
+
         energies, gradient = _calc_run(
             all_r_ijs,
             itypes,
@@ -58,6 +62,7 @@ class NumbaMTPEngine(EngineBase):
             mtp_data.radial_coeffs,
             mtp_data.species_coeffs,
             mtp_data.moment_coeffs,
+            self.mbd.values,
         )
 
         forces = _calc_forces_from_gradient(gradient, all_js)
@@ -144,6 +149,7 @@ def _calc_r_unit(r_ijs: np.ndarray, r_abs: np.ndarray) -> np.ndarray:
         nb.float64[:, :, :, :],
         nb.float64[:],
         nb.float64[:],
+        nb.float64[:],
     ),
     # parallel=True,
 )
@@ -161,6 +167,7 @@ def _calc_run(
     radial_coeffs: npt.NDArray[np.float64],
     species_coeffs: npt.NDArray[np.float64],
     moment_coeffs: npt.NDArray[np.float64],
+    mbd_values: npt.NDArray[np.float64],
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
 
     energies = species_coeffs[itypes]
@@ -189,6 +196,8 @@ def _calc_run(
             alpha_index_times,
             moment_coeffs,
         )
+
+        update_mbd_values(mbd_values, basis_values)
 
         for basis_i, coeff in enumerate(moment_coeffs):
             energies[i] += coeff * basis_values[basis_i]

--- a/motep/potentials/mtp/numba/engine.py
+++ b/motep/potentials/mtp/numba/engine.py
@@ -28,7 +28,14 @@ class NumbaMTPEngine(EngineBase):
     def __init__(self, *args: tuple, **kwargs: dict) -> None:
         """Intialize the engine."""
         super().__init__(*args, **kwargs)
-        self._calculate = self._calc_train if self._is_trained else self._calc_run
+
+    def _calculate(self, atoms: Atoms) -> tuple:
+        if len({_ for _ in atoms.numbers}) > self.mtp_data.species_count:
+            msg = "The number of species in input atoms is larger than species_count."
+            raise RuntimeError(msg)
+        if self._is_trained:
+            return self._calc_train(atoms)
+        return self._calc_run(atoms)
 
     def _calc_run(self, atoms: Atoms) -> tuple:
         mtp_data = self.mtp_data

--- a/motep/potentials/mtp/numba/engine.py
+++ b/motep/potentials/mtp/numba/engine.py
@@ -30,9 +30,6 @@ class NumbaMTPEngine(EngineBase):
         super().__init__(*args, **kwargs)
 
     def _calculate(self, atoms: Atoms) -> tuple:
-        if len({_ for _ in atoms.numbers}) > self.mtp_data.species_count:
-            msg = "The number of species in input atoms is larger than species_count."
-            raise RuntimeError(msg)
         if self._is_trained:
             return self._calc_train(atoms)
         return self._calc_run(atoms)


### PR DESCRIPTION
This PR adds:
- A check that at least the species count for the potential is not smaller than the number of species in `atoms`. This gives an error message that is easier to interpret than previously.
- `_calculate` in the numba engine is defined instead of set at instantiation, so that `_is_trained` is checked at runtime. This allows dynamically switching between `_calc_run` and `_calc_train` if one wants this at some point.
- The moment basis values are saved also in `_calc_run` so that they can be accessed