### PR TITLE
Add stress to default minimized for LLSOptimizerBase

### DIFF
--- a/motep/optimizers/lls.py
+++ b/motep/optimizers/lls.py
@@ -41,7 +41,7 @@ class LLSOptimizerBase(OptimizerBase):
         """Initialize the optimizer."""
         super().__init__(loss=loss, **kwargs)
         if minimized is None:
-            minimized = ["energy", "forces"]
+            minimized = ["energy", "forces", "stress"]
         self.minimized = minimized
 
     @abstractmethod


### PR DESCRIPTION
Since the default weights include all of energy, forces, and stress, include also these three in `minimized` by default, so that the LLS optimizations are consistent with the loss function.