### PR TITLE
Use Python logging instead of bare `print`

### DIFF
--- a/motep/__init__.py
+++ b/motep/__init__.py
@@ -1,6 +1,8 @@
 """motep."""
 
 import argparse
+import logging
+import sys
 
 from motep import (
     applier,
@@ -8,6 +10,12 @@ from motep import (
     trainer,
     upconverter,
 )
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+stdout_handler = logging.StreamHandler(sys.stdout)
+stdout_handler.setLevel(logging.INFO)
+logger.addHandler(stdout_handler)
 
 
 def main() -> None:

--- a/motep/applier.py
+++ b/motep/applier.py
@@ -1,8 +1,9 @@
 """`motep run` command."""
 
 import argparse
+import logging
 import pathlib
-import pprint
+from pprint import pformat
 
 from mpi4py import MPI
 
@@ -11,6 +12,8 @@ from motep.calculator import MTP
 from motep.io.mlip.mtp import read_mtp
 from motep.io.utils import get_dummy_species, read_images
 from motep.setting import load_setting_apply
+
+logger = logging.getLogger(__name__)
 
 
 def add_arguments(parser: argparse.ArgumentParser) -> None:
@@ -23,8 +26,10 @@ def apply(filename_setting: str, comm: MPI.Comm) -> None:
     rank = comm.Get_rank()
     setting = load_setting_apply(filename_setting)
     if rank == 0:
-        pprint.pp(setting)
-        print(flush=True)
+        logger.info(pformat(setting))
+        logger.info("")
+        for handler in logger.handlers:
+            handler.flush()
 
     mtp_file = str(pathlib.Path(setting.potential_final).resolve())
 

--- a/motep/grader.py
+++ b/motep/grader.py
@@ -1,8 +1,9 @@
 """`motep grade` command."""
 
 import argparse
+import logging
 import pathlib
-import pprint
+from pprint import pformat
 
 import numpy as np
 from mpi4py import MPI
@@ -12,6 +13,8 @@ from motep.active import AlgorithmBase, make_algorithm
 from motep.io.mlip.mtp import read_mtp
 from motep.io.utils import get_dummy_species, read_images
 from motep.setting import load_setting_grade
+
+logger = logging.getLogger(__name__)
 
 
 def add_arguments(parser: argparse.ArgumentParser) -> None:
@@ -27,8 +30,10 @@ def grade(filename_setting: str, comm: MPI.Comm) -> None:
     rank = comm.Get_rank()
     setting = load_setting_grade(filename_setting)
     if rank == 0:
-        pprint.pp(setting)
-        print(flush=True)
+        logger.info(pformat(setting))
+        logger.info("")
+        for handler in logger.handlers:
+            handler.flush()
 
     rng = np.random.default_rng(setting.seed)
 
@@ -61,10 +66,11 @@ def grade(filename_setting: str, comm: MPI.Comm) -> None:
     )
 
     if rank == 0:
-        print(f"{'':=^72s}\n")
-        print("[data_active]")
-        print(optimality.indices)
-        print(flush=True)
+        logger.info(f"{'':=^72s}\n")
+        logger.info("[data_active]")
+        logger.info(optimality.indices)
+        for handler in logger.handlers:
+            handler.flush()
 
     images_in = read_images(
         setting.data_in,

--- a/motep/io/utils.py
+++ b/motep/io/utils.py
@@ -1,9 +1,13 @@
 """IO unils."""
 
+import logging
+
 from ase import Atoms
 from mpi4py import MPI
 
 import motep.io
+
+logger = logging.getLogger(__name__)
 
 
 def get_dummy_species(images: list[Atoms]) -> list[int]:
@@ -24,11 +28,11 @@ def read_images(
     rank = comm.Get_rank()
     images = []
     if rank == 0:
-        print(f"{'':=^72s}\n")
-        print(f"[{title}]")
+        logger.info(f"{'':=^72s}\n")
+        logger.info(f"[{title}]")
         for filename in filenames:
             images_local = motep.io.read(filename, species)
             images.extend(images_local)
-            print(f'"{filename}" = {len(images_local)}')
-        print()
+            logger.info(f'"{filename}" = {len(images_local)}')
+        logger.info("")
     return comm.bcast(images, root=0)

--- a/motep/loss.py
+++ b/motep/loss.py
@@ -1,7 +1,7 @@
 """Loss function."""
 
+import logging
 from abc import ABC, abstractmethod
-from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -13,6 +13,8 @@ from scipy.constants import eV
 from motep.calculator import MTP
 from motep.potentials.mtp.data import MTPData
 from motep.setting import LossSetting
+
+logger = logging.getLogger(__name__)
 
 
 def _calc_errors_from_diff(diff: np.ndarray) -> dict[str, float]:
@@ -457,11 +459,8 @@ class ErrorPrinter:
         errors["stress"] = self._calc_errors_stress()  # eV/Ang^3
         return errors
 
-    def print(self, **kwargs: dict[str, Any]) -> dict[str, float]:
-        """Print errors.
-
-        `**kwargs` are used to, e.g., give `flush=True` for `print` at the end
-        of each block.
+    def log(self) -> dict[str, float]:
+        """Log errors.
 
         Returns
         -------
@@ -472,32 +471,32 @@ class ErrorPrinter:
         errors = self.calculate()
 
         key0 = "energy"
-        print("Energy (eV):")
-        print(f"    Errors checked for {errors[key0]['N']} configurations")
+        logger.info("Energy (eV):")
+        logger.info(f"    Errors checked for {errors[key0]['N']} configurations")
         for key1 in ["MAX", "ABS", "RMS"]:
-            print(f"    {key1} error: {errors[key0][key1]}")
-        print(**kwargs)
+            logger.info(f"    {key1} error: {errors[key0][key1]}")
+        logger.info("")
 
         key0 = "energy_per_atom"
-        print("Energy per atom (eV/atom):")
-        print(f"    Errors checked for {errors[key0]['N']} configurations")
+        logger.info("Energy per atom (eV/atom):")
+        logger.info(f"    Errors checked for {errors[key0]['N']} configurations")
         for key1 in ["MAX", "ABS", "RMS"]:
-            print(f"    {key1} error: {errors[key0][key1]}")
-        print(**kwargs)
+            logger.info(f"    {key1} error: {errors[key0][key1]}")
+        logger.info("")
 
         key0 = "forces"
-        print("Forces per component (eV/angstrom):")
-        print(f"    Errors checked for {errors[key0]['N'] // 3} atoms")
+        logger.info("Forces per component (eV/angstrom):")
+        logger.info(f"    Errors checked for {errors[key0]['N'] // 3} atoms")
         for key1 in ["MAX", "ABS", "RMS"]:
-            print(f"    {key1} error: {errors[key0][key1]}")
-        print(**kwargs)
+            logger.info(f"    {key1} error: {errors[key0][key1]}")
+        logger.info("")
 
         key0 = "stress"
-        print("Stress per component (GPa):")
-        print(f"    Errors checked for {errors[key0]['N'] // 9} configurations")
+        logger.info("Stress per component (GPa):")
+        logger.info(f"    Errors checked for {errors[key0]['N'] // 9} configurations")
         for key1 in ["MAX", "ABS", "RMS"]:
-            print(f"    {key1} error: {errors[key0][key1] * eV * 1e21}")
-        print(**kwargs)
+            logger.info(f"    {key1} error: {errors[key0][key1] * eV * 1e21}")
+        logger.info("")
 
         return errors
 

--- a/motep/optimizers/ga.py
+++ b/motep/optimizers/ga.py
@@ -1,5 +1,6 @@
 """Optiimzers based on genetic algorithm (GA)."""
 
+import logging
 import random
 from collections.abc import Callable
 from typing import Any
@@ -8,6 +9,8 @@ import numpy as np
 from scipy.optimize import minimize
 
 from motep.optimizers.base import OptimizerBase
+
+logger = logging.getLogger(__name__)
 
 
 def _limit_bounds(bounds: np.ndarray) -> np.ndarray:
@@ -254,7 +257,7 @@ class GeneticAlgorithm:
 
 
 def elite_callback(gen: int, elite: float) -> None:
-    print(f"Generation {gen}: Top Elite - {elite}")
+    logger.info(f"Generation {gen}: Top Elite - {elite}")
 
 
 class GeneticAlgorithmOptimizer(OptimizerBase):

--- a/motep/optimizers/level2mtp.py
+++ b/motep/optimizers/level2mtp.py
@@ -1,7 +1,6 @@
 """Optimizer for Level 2 MTP."""
 
 import logging
-import sys
 from math import sqrt
 from typing import Any
 
@@ -12,8 +11,6 @@ from motep.optimizers.lls import LLSOptimizerBase
 from motep.optimizers.scipy import Callback
 
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.StreamHandler(sys.stdout))
-logger.setLevel(logging.INFO)
 
 
 class Level2MTPOptimizer(LLSOptimizerBase):
@@ -48,11 +45,11 @@ class Level2MTPOptimizer(LLSOptimizerBase):
 
         # Prepare and solve the LLS problem
         if self.comm.Get_rank() == 0:
-            logger.info("Calculate `matrix`")
+            logger.debug("Calculate `matrix`")
             matrix = self._calc_matrix()
-            logger.info("Calculate `vector`")
+            logger.debug("Calculate `vector`")
             vector = self._calc_vector()
-            logger.info("Calculate `coeffs`")
+            logger.debug("Calculate `coeffs`")
             coeffs = np.linalg.lstsq(matrix, vector, rcond=None)[0]
         else:
             coeffs = None

--- a/motep/optimizers/lls.py
+++ b/motep/optimizers/lls.py
@@ -1,7 +1,6 @@
 """Module for the optimizer based on linear least squares (LLS)."""
 
 import logging
-import sys
 from abc import abstractmethod
 from math import sqrt
 from typing import Any
@@ -16,8 +15,6 @@ from motep.optimizers.scipy import Callback
 from motep.potentials.mtp import get_types
 
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.StreamHandler(sys.stdout))
-logger.setLevel(logging.INFO)
 
 
 class LLSOptimizerBase(OptimizerBase):
@@ -202,11 +199,11 @@ class LLSOptimizer(LLSOptimizerBase):
 
         # Prepare and solve the LLS problem
         if self.comm.Get_rank() == 0:
-            logger.info("Calculate `matrix`")
+            logger.debug("Calculate `matrix`")
             matrix = self._calc_matrix()
-            logger.info("Calculate `vector`")
+            logger.debug("Calculate `vector`")
             vector = self._calc_vector()
-            logger.info("Calculate `coeffs`")
+            logger.debug("Calculate `coeffs`")
             coeffs = np.linalg.lstsq(matrix, vector, rcond=None)[0]
         else:
             coeffs = None

--- a/motep/optimizers/scipy.py
+++ b/motep/optimizers/scipy.py
@@ -1,8 +1,8 @@
 """Optimizers based on SciPy."""
 
+import logging
 from typing import Any
 
-import numpy as np
 from scipy.optimize import (
     OptimizeResult,
     differential_evolution,
@@ -12,6 +12,8 @@ from scipy.optimize import (
 
 from motep.loss import LossFunctionBase
 from motep.optimizers.base import OptimizerBase
+
+logger = logging.getLogger(__name__)
 
 
 class Callback:
@@ -24,7 +26,9 @@ class Callback:
     def __call__(self, intermediate_result: OptimizeResult):
         fun = intermediate_result.fun
         if self.loss.comm.Get_rank() == 0:
-            print(f"loss {self.iter:4d}:", fun, flush=True)
+            logger.info(f"loss {self.iter:4d}: {fun}")
+            for handler in logger.handlers:
+                handler.flush()
         self.iter += 1
 
 
@@ -40,15 +44,17 @@ class ScipyOptimizerBase(OptimizerBase):
     def print_result(self, result: OptimizeResult) -> None:
         """Print `result`."""
         if self.loss.comm.Get_rank() == 0:
-            print(flush=True)
-            print("Optimization result:")
-            print("  Message:", result.message)
-            print("  Success:", result.success)
-            print("  Status code:", result.status)
-            print("  Number of function evaluations:", result.nfev)
-            print("  Number of iterations:", result.nit)
-            # print("  Final parameters:", result.x)
-            # print("  Final function value:", result.fun)
+            logger.info("")
+            for handler in logger.handlers:
+                handler.flush()
+            logger.info(f"Optimization result:")
+            logger.info(f"  Message: {result.message}")
+            logger.info(f"  Success: {result.success}")
+            logger.info(f"  Status code: {result.status}")
+            logger.info(f"  Number of function evaluations: {result.nfev}")
+            logger.info(f"  Number of iterations: {result.nit}")
+            # logger.info(f"  Final parameters: {result.x}")
+            # logger.info(f"  Final function value: {result.fun}")
 
 
 class ScipyDualAnnealingOptimizer(ScipyOptimizerBase):

--- a/motep/potentials/mtp/data.py
+++ b/motep/potentials/mtp/data.py
@@ -1,10 +1,12 @@
 """Initializer."""
 
+import logging
 from dataclasses import dataclass, field
-from typing import Any
 
 import numpy as np
 import numpy.typing as npt
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -130,17 +132,15 @@ class MTPData:
             tmp.extend([(-np.inf, +np.inf)] * self.radial_coeffs.size)
         return np.vstack(tmp)
 
-    def print(self, **kwargs: dict[str, Any]) -> None:
-        """Print parameters.
-
-        `**kwargs` are used to, e.g., give `flush=True` for `print` at the end
-        of each block.
-        """
-        print("scaling:", self.scaling)
-        print("moment_coeffs:")
-        print(self.moment_coeffs)
-        print("species_coeffs:")
-        print(self.species_coeffs)
-        print("radial_coeffs:")
-        print(self.radial_coeffs)
-        print(**kwargs)
+    def log(self) -> None:
+        """Log parameters."""
+        logger.debug(f"scaling: {self.scaling}")
+        logger.debug("moment_coeffs:")
+        logger.debug(self.moment_coeffs)
+        logger.debug("species_coeffs:")
+        logger.debug(self.species_coeffs)
+        logger.debug("radial_coeffs:")
+        logger.debug(self.radial_coeffs)
+        logger.debug("")
+        for handler in logger.handlers:
+            handler.flush()

--- a/tests/optimizers/test_level2mtp.py
+++ b/tests/optimizers/test_level2mtp.py
@@ -1,5 +1,6 @@
 """Tests for `Level2MTPOptimizer`."""
 
+import logging
 import pathlib
 
 import numpy as np
@@ -14,6 +15,8 @@ from motep.optimizers.ideal import NoInteractionOptimizer
 from motep.optimizers.level2mtp import Level2MTPOptimizer
 from motep.potentials.mtp.data import MTPData
 from motep.setting import LossSetting
+
+logger = logging.getLogger(__name__)
 
 
 def make_molecules(
@@ -156,9 +159,9 @@ def test_molecules(
     optimizer.optimize()
     print()
 
-    mtp_data.print()
+    mtp_data.log()
     f_ref = loss(mtp_data.parameters)  # update paramters
-    ErrorPrinter(loss).print()
+    ErrorPrinter(loss).log()
 
     parameters_ref = np.array(mtp_data.parameters, copy=True)
 
@@ -169,9 +172,9 @@ def test_molecules(
     optimizer.optimize()
     print()
 
-    mtp_data.print()
+    mtp_data.log()
     f_e00 = loss(mtp_data.parameters)  # update paramters
-    ErrorPrinter(loss).print()
+    ErrorPrinter(loss).log()
 
     # Check if `parameters` are updated.
     assert (mtp_data.parameters.size != parameters_ref.size) or (
@@ -261,9 +264,9 @@ def test_crystals(
     optimizer.optimize()
     print()
 
-    mtp_data.print()
+    mtp_data.log()
     loss(mtp_data.parameters)  # update parameters
-    ErrorPrinter(loss).print()
+    ErrorPrinter(loss).log()
 
     parameters_ref = np.array(mtp_data.parameters, copy=True)
 
@@ -272,9 +275,9 @@ def test_crystals(
     optimizer.optimize()
     print()
 
-    mtp_data.print()
+    mtp_data.log()
     f0 = loss(mtp_data.parameters)  # update parameters
-    errors0 = ErrorPrinter(loss).print()
+    errors0 = ErrorPrinter(loss).log()
 
     # Check if `parameters` are updated.
     parameters = mtp_data.parameters
@@ -287,9 +290,9 @@ def test_crystals(
     optimizer.optimize()
     print()
 
-    mtp_data.print()
+    mtp_data.log()
     f1 = loss(mtp_data.parameters)  # update parameters
-    errors1 = ErrorPrinter(loss).print()
+    errors1 = ErrorPrinter(loss).log()
 
     # Check RMSEs
     # When only the RMSE of the energies is minimized, it should be smaller than
@@ -302,9 +305,9 @@ def test_crystals(
     optimizer.optimize()
     print()
 
-    mtp_data.print()
+    mtp_data.log()
     f2 = loss(mtp_data.parameters)  # update parameters
-    errors2 = ErrorPrinter(loss).print()
+    errors2 = ErrorPrinter(loss).log()
 
     # Check RMSEs
     assert errors1["stress"]["RMS"] > errors2["stress"]["RMS"]
@@ -358,7 +361,7 @@ def test_species_coeffs(
     optimizer.optimize()
     print()
 
-    mtp_data.print()
+    mtp_data.log()
     loss(mtp_data.parameters)  # update parameters
 
     optimized = ["radial_coeffs"]
@@ -366,7 +369,7 @@ def test_species_coeffs(
     optimizer.optimize()
     print()
 
-    mtp_data.print()
+    mtp_data.log()
     f0 = loss(mtp_data.parameters)  # update parameters
 
     optimized = ["radial_coeffs", "species_coeffs"]
@@ -374,7 +377,7 @@ def test_species_coeffs(
     optimizer.optimize()
     print()
 
-    mtp_data.print()
+    mtp_data.log()
     f1 = loss(mtp_data.parameters)  # update parameters
 
     # Check loss functions

--- a/tests/optimizers/test_lls.py
+++ b/tests/optimizers/test_lls.py
@@ -1,5 +1,6 @@
 """Tests for `LLSOptimizer`."""
 
+import logging
 import pathlib
 
 import numpy as np
@@ -13,6 +14,8 @@ from motep.loss import ErrorPrinter, LossFunction
 from motep.optimizers.lls import LLSOptimizer
 from motep.potentials.mtp.data import MTPData
 from motep.setting import LossSetting
+
+logger = logging.getLogger(__name__)
 
 
 def make_molecules(
@@ -68,7 +71,7 @@ def test_without_forces(data_path: pathlib.Path) -> None:
     mtp_data.optimized = optimized
     mtp_data.initialize(rng=rng)
 
-    mtp_data.print()
+    mtp_data.log()
 
     loss = LossFunction(
         images,
@@ -108,7 +111,7 @@ def test_molecules(
     mtp_data.optimized = optimized
     mtp_data.initialize(rng=rng)
 
-    mtp_data.print()
+    mtp_data.log()
 
     loss = LossFunction(
         images,
@@ -120,16 +123,16 @@ def test_molecules(
 
     parameters_ref = np.array(mtp_data.parameters, copy=True)
     loss(parameters_ref)  # update paramters
-    ErrorPrinter(loss).print()
+    ErrorPrinter(loss).log()
 
     minimized = ["energy"]
     optimizer = LLSOptimizer(loss, optimized=optimized, minimized=minimized)
     optimizer.optimize()
     print()
 
-    mtp_data.print()
+    mtp_data.log()
     f0 = loss(mtp_data.parameters)  # update paramters
-    errors0 = ErrorPrinter(loss).print()
+    errors0 = ErrorPrinter(loss).log()
 
     # Check if `parameters` are updated.
     assert (mtp_data.parameters.size != parameters_ref.size) or (
@@ -141,9 +144,9 @@ def test_molecules(
     optimizer.optimize()
     print()
 
-    mtp_data.print()
+    mtp_data.log()
     f1 = loss(mtp_data.parameters)  # update parameters
-    errors1 = ErrorPrinter(loss).print()
+    errors1 = ErrorPrinter(loss).log()
 
     # Check loss functions
     # The value should be smaller when considering both energies and forces than
@@ -227,18 +230,18 @@ def test_crystals(
     )
 
     parameters_ref = np.array(mtp_data.parameters, copy=True)
-    mtp_data.print()
+    mtp_data.log()
     loss(parameters_ref)  # update parameters
-    ErrorPrinter(loss).print()
+    ErrorPrinter(loss).log()
 
     minimized = ["energy"]
     optimizer = LLSOptimizer(loss, optimized=optimized, minimized=minimized)
     optimizer.optimize()
     print()
 
-    mtp_data.print()
+    mtp_data.log()
     f0 = loss(mtp_data.parameters)  # update parameters
-    errors0 = ErrorPrinter(loss).print()
+    errors0 = ErrorPrinter(loss).log()
 
     # Check if `parameters` are updated.
     assert (mtp_data.parameters.size != parameters_ref.size) or (
@@ -250,9 +253,9 @@ def test_crystals(
     optimizer.optimize()
     print()
 
-    mtp_data.print()
+    mtp_data.log()
     f1 = loss(mtp_data.parameters)  # update parameters
-    errors1 = ErrorPrinter(loss).print()
+    errors1 = ErrorPrinter(loss).log()
 
     # Check RMSEs
     # When only the RMSE of the energies is minimized, it should be smaller than
@@ -265,9 +268,9 @@ def test_crystals(
     optimizer.optimize()
     print()
 
-    mtp_data.print()
+    mtp_data.log()
     f2 = loss(mtp_data.parameters)  # update parameters
-    errors2 = ErrorPrinter(loss).print()
+    errors2 = ErrorPrinter(loss).log()
 
     # Check RMSEs
     assert errors1["stress"]["RMS"] > errors2["stress"]["RMS"]
@@ -318,7 +321,7 @@ def test_species_coeffs(
     optimizer.optimize()
     print()
 
-    mtp_data.print()
+    mtp_data.log()
     f0 = loss(mtp_data.parameters)  # update parameters
 
     optimized = ["moment_coeffs", "species_coeffs"]
@@ -326,7 +329,7 @@ def test_species_coeffs(
     optimizer.optimize()
     print()
 
-    mtp_data.print()
+    mtp_data.log()
     f1 = loss(mtp_data.parameters)  # update parameters
 
     # Check loss functions

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -1,5 +1,6 @@
 """Tests for trainer.py."""
 
+import logging
 import pathlib
 
 import numpy as np
@@ -10,6 +11,8 @@ from motep.io.mlip.cfg import read_cfg
 from motep.io.mlip.mtp import read_mtp
 from motep.loss import ErrorPrinter, LossFunction
 from motep.setting import LossSetting
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("forces_per_atom", [False, True])
@@ -42,7 +45,7 @@ def test_without_forces(*, forces_per_atom: bool, data_path: pathlib.Path) -> No
 
     loss(mtp_data.parameters)
     loss.jac(mtp_data.parameters)
-    ErrorPrinter(loss).print()
+    ErrorPrinter(loss).log(logger)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR starts to use the Python logging mechanism instead of bare `print`.

So far this is just a straightforward replacement of `print`, but in future this allows us better control for logging.

Hopefully all the `print` statements have been replaced with `logging.{info,debug}`, except those in tests as well as benchmarking scripts.

The next step will be to pass detailed logging setting maybe via `motep.toml`, which will be in a separate PR.

@axefor Could you kindly review the PR critically, as I am new for the Python logging mechanism.