### PR TITLE
Update only first radial function in Level2MTP training.

### DIFF
--- a/motep/optimizers/level2mtp.py
+++ b/motep/optimizers/level2mtp.py
@@ -75,8 +75,7 @@ class Level2MTPOptimizer(LLSOptimizerBase):
         mtp_data.scaling = 1.0
         mtp_data.moment_coeffs[...] = 0.0
         mtp_data.moment_coeffs[000] = 1.0
-        mtp_data.radial_coeffs[000] = 0.0
-        mtp_data.radial_coeffs[...] = coeffs[:size].reshape(shape)[:, :, None, :]
+        mtp_data.radial_coeffs[:, :, 0, :] = coeffs[:size].reshape(shape)[:, :, :]
         if "species_coeffs" in self.optimized:
             mtp_data.species_coeffs = coeffs[size:]
 


### PR DESCRIPTION
This PR changes the Level2MTP optimizer to update only the "first" radial coefficients, i.e. those that correspond to $\mu=0$. Previously all were set the same, while this PR keeps them as initialized, for example random. This allows a better optimization of the moment coefficients in a next step with the LLS optimizer.