### PR TITLE
Avoid modifying calculators

### DIFF
--- a/motep/loss.py
+++ b/motep/loss.py
@@ -324,6 +324,12 @@ class LossFunctionBase(ABC):
         comm : MPI.Comm
             MPI.Comm object.
 
+        Notes
+        -----
+        This class creates a lightweight shallow copy of the provided Atoms
+        objects. Atomic positions and arrays are treated as immutable and are
+        shared with the input. Only the calculator is replaced internally.
+
         """
         self.images = [copy(_) for _ in images]
         self.mtp_data = mtp_data


### PR DESCRIPTION
Make shallow copy of atoms' in LossFunction init to not modify their original calculators later.

In LossFunction __init__(...), the atoms.calc are set to new MTP instances and the previous calculators are discarded after their results are put to the target attribute. This edits the atoms objects provided by the used, which might be unexpected. A possible use case is where two separate trainings are performed in the same script for comparison. Then the atoms' calculators need to be intact for the second training to work.

This PR solves this by shallow copy the atoms' instances. This saves memory by keeping references to the same data, but avoids changing the original calculator.