### PR TITLE
Use `rank` and `size` attributes for `MPI.Comm`

### DIFF
--- a/motep/applier.py
+++ b/motep/applier.py
@@ -23,9 +23,8 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
 
 def apply(filename_setting: str, comm: MPI.Comm) -> None:
     """Run."""
-    rank = comm.Get_rank()
     setting = load_setting_apply(filename_setting)
-    if rank == 0:
+    if comm.rank == 0:
         logger.info(pformat(setting))
         logger.info("")
         for handler in logger.handlers:

--- a/motep/grader.py
+++ b/motep/grader.py
@@ -27,9 +27,8 @@ def grade(filename_setting: str, comm: MPI.Comm) -> None:
 
     This adds `MV_grade` to `atoms.info`.
     """
-    rank = comm.Get_rank()
     setting = load_setting_grade(filename_setting)
-    if rank == 0:
+    if comm.rank == 0:
         logger.info(pformat(setting))
         logger.info("")
         for handler in logger.handlers:
@@ -65,7 +64,7 @@ def grade(filename_setting: str, comm: MPI.Comm) -> None:
         rng=rng,
     )
 
-    if rank == 0:
+    if comm.rank == 0:
         logger.info(f"{'':=^72s}\n")
         logger.info("[data_active]")
         logger.info(optimality.indices)

--- a/motep/io/utils.py
+++ b/motep/io/utils.py
@@ -25,9 +25,8 @@ def read_images(
     title: str = "data",
 ) -> list[Atoms]:
     """Read images."""
-    rank = comm.Get_rank()
     images = []
-    if rank == 0:
+    if comm.rank == 0:
         logger.info(f"{'':=^72s}\n")
         logger.info(f"[{title}]")
         for filename in filenames:

--- a/motep/loss.py
+++ b/motep/loss.py
@@ -66,11 +66,9 @@ class LossFunctionEnergy:
             Energy contribution to the loss function.
 
         """
-        rank = self.comm.Get_rank()
-        size = self.comm.Get_size()
         ncnf = len(self.images)
         loss_cnf = 0.0
-        for i in range(rank, ncnf, size):
+        for i in range(self.comm.rank, ncnf, self.comm.size):
             atoms = self.images[i]
             target = atoms.calc.targets["energy"]
             result = atoms.calc.results["energy"]
@@ -90,13 +88,11 @@ class LossFunctionEnergy:
             Energy contribution to the loss function Jacobian.
 
         """
-        rank = self.comm.Get_rank()
-        size = self.comm.Get_size()
         ncnf = len(self.images)
         nprm = self.mtp_data.number_of_parameters_optimized
         jac_cnf = np.zeros(nprm)
         jac_all = np.zeros(nprm)
-        for i in range(rank, ncnf, size):
+        for i in range(self.comm.rank, ncnf, self.comm.size):
             atoms = self.images[i]
             target = atoms.calc.targets["energy"]
             result = atoms.calc.results["energy"]
@@ -158,11 +154,9 @@ class LossFunctionForces:
             Force contribution to the loss function.
 
         """
-        rank = self.comm.Get_rank()
-        size = self.comm.Get_size()
         ncnf = len(self.images)
         loss_cnf = 0.0
-        for i in range(rank, ncnf, size):
+        for i in range(self.comm.rank, ncnf, self.comm.size):
             if i not in self.idcs_frc:
                 continue
             atoms = self.images[i]
@@ -184,12 +178,10 @@ class LossFunctionForces:
             Force contribution to the loss function Jacobian.
 
         """
-        rank = self.comm.Get_rank()
-        size = self.comm.Get_size()
         ncnf = len(self.images)
         jac_cnf = np.zeros(self.mtp_data.number_of_parameters_optimized)
         jac_all = np.zeros(self.mtp_data.number_of_parameters_optimized)
-        for i in range(rank, ncnf, size):
+        for i in range(self.comm.rank, ncnf, self.comm.size):
             if i not in self.idcs_frc:
                 continue
             atoms = self.images[i]
@@ -252,12 +244,10 @@ class LossFunctionStress:
             Stress contribution to the loss function.
 
         """
-        rank = self.comm.Get_rank()
-        size = self.comm.Get_size()
         ncnf = len(self.images)
         f = voigt_6_to_full_3x3_stress
         loss_cnf = 0.0
-        for i in range(rank, ncnf, size):
+        for i in range(self.comm.rank, ncnf, self.comm.size):
             if i not in self.idcs_str:
                 continue
             atoms = self.images[i]
@@ -279,13 +269,11 @@ class LossFunctionStress:
             Stress contribution to the loss function Jacobian.
 
         """
-        rank = self.comm.Get_rank()
-        size = self.comm.Get_size()
         ncnf = len(self.images)
         f = voigt_6_to_full_3x3_stress
         jac_cnf = np.zeros(self.mtp_data.number_of_parameters_optimized)
         jac_all = np.zeros(self.mtp_data.number_of_parameters_optimized)
-        for i in range(rank, ncnf, size):
+        for i in range(self.comm.rank, ncnf, self.comm.size):
             if i not in self.idcs_str:
                 continue
             atoms = self.images[i]
@@ -364,15 +352,13 @@ class LossFunctionBase(ABC):
 
     def _run_calculations(self) -> None:
         """Run calculations of the properties."""
-        rank = self.comm.Get_rank()
-        size = self.comm.Get_size()
         ncnf = len(self.images)
-        for i in range(rank, ncnf, size):
+        for i in range(self.comm.rank, ncnf, self.comm.size):
             self.images[i].get_potential_energy()
 
     def broadcast(self) -> None:
         """Broadcast data."""
-        size = self.comm.Get_size()
+        size = self.comm.size
         ncnf = len(self.images)
         for i in range(ncnf):
             results = self.images[i].calc.results

--- a/motep/optimizers/level2mtp.py
+++ b/motep/optimizers/level2mtp.py
@@ -44,7 +44,7 @@ class Level2MTPOptimizer(LLSOptimizerBase):
         callback(OptimizeResult(x=parameters, fun=loss_value))
 
         # Prepare and solve the LLS problem
-        if self.comm.Get_rank() == 0:
+        if self.comm.rank == 0:
             logger.debug("Calculate `matrix`")
             matrix = self._calc_matrix()
             logger.debug("Calculate `vector`")

--- a/motep/optimizers/lls.py
+++ b/motep/optimizers/lls.py
@@ -198,7 +198,7 @@ class LLSOptimizer(LLSOptimizerBase):
         callback(OptimizeResult(x=parameters, fun=loss_value))
 
         # Prepare and solve the LLS problem
-        if self.comm.Get_rank() == 0:
+        if self.comm.rank == 0:
             logger.debug("Calculate `matrix`")
             matrix = self._calc_matrix()
             logger.debug("Calculate `vector`")

--- a/motep/optimizers/scipy.py
+++ b/motep/optimizers/scipy.py
@@ -25,7 +25,7 @@ class Callback:
 
     def __call__(self, intermediate_result: OptimizeResult):
         fun = intermediate_result.fun
-        if self.loss.comm.Get_rank() == 0:
+        if self.loss.comm.rank == 0:
             logger.info(f"loss {self.iter:4d}: {fun}")
             for handler in logger.handlers:
                 handler.flush()
@@ -43,7 +43,7 @@ class ScipyOptimizerBase(OptimizerBase):
 
     def print_result(self, result: OptimizeResult) -> None:
         """Print `result`."""
-        if self.loss.comm.Get_rank() == 0:
+        if self.loss.comm.rank == 0:
             logger.info("")
             for handler in logger.handlers:
                 handler.flush()

--- a/motep/upconverter.py
+++ b/motep/upconverter.py
@@ -141,8 +141,6 @@ def run(args: argparse.Namespace) -> None:
     """Run."""
     comm = MPI.COMM_WORLD
 
-    rank = comm.Get_rank()
-
     setting = load_setting_upconvert(args.setting)
 
     src = read_mtp(setting.potentials.base)
@@ -150,5 +148,5 @@ def run(args: argparse.Namespace) -> None:
 
     upconvert(src, dst)
 
-    if rank == 0:
+    if comm.rank == 0:
         write_mtp(setting.potentials.final, dst)

--- a/motep/utils.py
+++ b/motep/utils.py
@@ -44,5 +44,5 @@ def measure_time(name: str, comm: MPI.Comm = MPI.COMM_WORLD) -> typing.Generator
         yield
     finally:
         end_time = time.perf_counter()
-        if comm.Get_rank() == 0:
+        if comm.rank == 0:
             print(f"Time ({name}): {end_time - start_time} (s)\n", flush=True)


### PR DESCRIPTION
This is a maintenance PR to replace `comm.Get_rank()` and `comm.Get_size` methods with `comm.rank` and `comm.size` attributes to be more pythonic. Hopefully this does not change any behaviors.

@axefor Could you have a short look when you have time and, if OK, merge?