### PR TITLE
Use `setuptools_scm` for dynamic version decision

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,9 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=80", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "motep"
-version = "0.1.0"
 dependencies = [
     "ase",
     "mpi4py",
@@ -17,6 +16,7 @@ authors = [
     {name = "Axel Forslund"},  # calculator
     {name = "Yuji Ikeda"},  # testing
 ]
+dynamic = ["version"]
 
 [project.optional-dependencies]
 jax = [
@@ -28,6 +28,8 @@ motep = "motep.__init__:main"
 
 [tool.setuptools.packages]
 find = {}
+
+[tool.setuptools_scm]
 
 [tool.ruff.lint]
 preview = true  # necessary to activate many pycodestyle rules


### PR DESCRIPTION
This PR suggests assigning a unique dynamic version for development (and released) `motep` using [`setuptools_scm`](https://setuptools-scm.readthedocs.io/en/latest/).

This is toward uploading the package (first to TestPyPI and then public) PyPI.
Since TestPyPI/PyPI accepts a certain version number only once (= no fix for the same version number is possible), it would be nice to assign a unique version number for the development version based on Git metadata, which `setuptools_scm` helps.

With this update, for example, the present `motep` version number would be given by
```
pip list | grep motep
```
as
```
motep                                0.1.dev715+gc23dd056a.d20260126 /Users/ikeda/codes/motep
```

@axefor Is this update OK for you?