### PR TITLE
Maxvol pass with warning

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Unreleased
 
 Changed
 ~~~~~~~
+- ``MaxVolAlgorithm`` now emits a warning instead of raising a ``RuntimeError`` when
+  the maxvol algorithm does not converge within ``maxiter`` iterations.
 - Changed the default of ``LossSetting.stress_times_volume`` from ``False`` to ``True``.
   This affects how stress residuals are weighted in the loss (stress contributions are
   scaled by the configuration volume), so training results may differ for existing

--- a/motep/active/algorithms.py
+++ b/motep/active/algorithms.py
@@ -1,5 +1,6 @@
 """Module for algorithms."""
 
+import logging
 from abc import ABC, abstractmethod
 from itertools import combinations
 from math import comb
@@ -9,6 +10,8 @@ from ase import Atoms
 
 from motep.calculator import MTP
 from motep.potentials.mtp.data import MTPData
+
+logger = logging.getLogger(__name__)
 
 
 class AlgorithmBase(ABC):
@@ -27,12 +30,14 @@ class AlgorithmBase(ABC):
         mtp_data: MTPData,
         engine: str,
         rng: np.random.Generator,
+        maxiter: int = 100_000,
     ) -> None:
         """Active-set finder."""
         self.images_training = images_training
         self.mtp_data = mtp_data
         self.engine = engine
         self.rng = rng
+        self.maxiter = maxiter
         self.update()
 
     def update(self) -> None:
@@ -114,7 +119,7 @@ class MaxVolAlgorithm(ExhaustiveAlgorithm):
         flags[indices] = True
 
         tolerance = 1e-9
-        for _ in range(65536):  # arbitrary large number for safety
+        for _ in range(self.maxiter):  # arbitrary large number for safety
             submatrix = matrix[flags]
             c = matrix @ np.linalg.inv(submatrix)
             i, j = np.divmod(np.argmax(np.abs(c)), asm)
@@ -123,6 +128,11 @@ class MaxVolAlgorithm(ExhaustiveAlgorithm):
             k = np.where(flags)[0][j]  # row/column in the original matrix
             flags[[k, i]] = flags[[i, k]]
         else:
-            raise RuntimeError(_)
+            cmax = np.abs(c[i, j])
+            msg = (
+                f"Maxvol algorithm did not converge within {_} iterations. "
+                f"Current c-max: {cmax}"
+            )
+            logger.warning(msg)
 
         self.indices = np.where(flags)[0]

--- a/motep/grader.py
+++ b/motep/grader.py
@@ -62,6 +62,7 @@ def grade(filename_setting: str, comm: MPI.Comm) -> None:
         mtp_data,
         setting.engine,
         rng=rng,
+        maxiter=setting.maxiter,
     )
 
     if comm.rank == 0:

--- a/motep/setting.py
+++ b/motep/setting.py
@@ -111,6 +111,7 @@ class GradeSetting(Setting):
     """Setting for the extrapolation-grade calculations."""
 
     algorithm: str = "maxvol"
+    maxiter: int = 100_000
 
 
 @dataclass


### PR DESCRIPTION
This PR changes the behavior of the `MaxVolAlgorithm.find_active_set()` if the tolerance is not achieved within the maximum number of iterations. `maxiter` can now be set in `GradeSetting`, and if tolerance is not achieved, it still passes buth with a warning informing about the current max(c).