### PR TITLE
Fix incorrect stress weighting in linear optimizers.

### DIFF
--- a/motep/optimizers/level2mtp.py
+++ b/motep/optimizers/level2mtp.py
@@ -157,6 +157,10 @@ class Level2MTPOptimizer(LLSOptimizerBase):
         matrix = np.array([images[i].calc.engine.rbd.dqdeps.T for i in idcs])
         if self.loss.setting.stress_times_volume:
             matrix = (matrix.T * self.loss.loss_stress.volumes[idcs]).T
+            if self.loss.setting.energy_per_atom:
+                matrix = (
+                    matrix.T * self.loss.loss_energy.inverse_numbers_of_atoms[idcs]
+                ).T
         if self.loss.setting.stress_per_conf:
             matrix /= sqrt(len(images))
         return matrix.reshape((-1, size))

--- a/motep/optimizers/lls.py
+++ b/motep/optimizers/lls.py
@@ -162,6 +162,11 @@ class LLSOptimizerBase(OptimizerBase):
         stresses = np.array([f(images[i].calc.targets[key]) for i in idcs_str])
         if self.loss.setting.stress_times_volume:
             stresses = (stresses.T * self.loss.loss_stress.volumes[idcs_str]).T
+            if self.loss.setting.energy_per_atom:
+                stresses = (
+                    stresses.T
+                    * self.loss.loss_stress.inverse_numbers_of_atoms[idcs_str]
+                ).T
         if self.loss.setting.stress_per_conf:
             stresses /= sqrt(len(images))
         return stresses.flat
@@ -282,6 +287,10 @@ class LLSOptimizer(LLSOptimizerBase):
         matrix = np.array([images[i].calc.engine.mbd.dbdeps.T for i in idcs_str])
         if self.loss.setting.stress_times_volume:
             matrix = (matrix.T * self.loss.loss_stress.volumes[idcs_str]).T
+            if self.loss.setting.energy_per_atom:
+                matrix = (
+                    matrix.T * self.loss.loss_stress.inverse_numbers_of_atoms[idcs_str]
+                ).T
         if self.loss.setting.stress_per_conf:
             matrix /= sqrt(len(images))
         return matrix.reshape((-1, self.loss.mtp_data.alpha_scalar_moments))


### PR DESCRIPTION
In PR https://github.com/imw-md/motep/pull/42 , a different weighting if `stress_times_volume=True` was introduced in `loss.py`. However, corresponding changes in `lls.py` and `level2mtp.py` were missing. This PR amends this.