### PR TITLE
Use `cibuildwheel` for building wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         run: python -m pip install cibuildwheel
       - name: Build wheels
         env:
-          CIBW_BUILD: "cp311-*"
+          CIBW_BUILD: "cp311-* cp312-* cp313-* cp314-*"
           CIBW_SKIP: "*-musllinux*"
           CIBW_TEST_COMMAND: >-
             python -c "from motep.potentials.mtp.cext import _mtp_cext"


### PR DESCRIPTION
This PR is on top of #51 and marked as draft until that PR is merged.

This PR suggests using `cibuildwheel` (rather than the basic `build` package) so that:

1. We can make wheels that are valid for many Linux environments (not only `ubuntu-latest`)
2. We can make wheels for multiple CPython versions

When we upload `motep` to PyPI, these wheels make it available for users with many environments without troubles related to `cext` installation (as wheels pre-compile it).

We can find the built wheels in e.g. https://github.com/yuzie007/motep/actions/runs/23059500033.