### PR TITLE
Fix module documentation made from their docstrings automatically

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,8 +23,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -32,7 +31,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install sphinx sphinx_book_theme numpydoc
+          python -m pip install meson-python setuptools_scm
+          python -m pip install numpy">=2,<3"  # numpy 2.x.x for build
+          python -m pip install numba jax
+          python -m pip install --no-build-isolation -e .[doc]
       - name: Build Sphinx docs
         run: |
           make -C docs html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,11 @@ mpi = ["mpi4py"]
 jax = [
   "jax",
 ]
+doc = [
+  "sphinx",
+  "sphinx_book_theme",
+  "numpydoc",
+]
 
 [project.scripts]
 motep = "motep.__init__:main"


### PR DESCRIPTION
This PR enables the [`sphinx.ext.autodoc`](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html) documentation by installing the `motep` package in `docs.yml`.

For example, https://imw-md.github.io/motep/optimizers/linear.html is supposed to show the details of the linear optimizer classes automatically made from their docstrings with `sphinx.ext.autodoc`. Presently, however, this is not properly done because I forgot to install `motep` in `docs.yml`. The present PR fixes this. I tested this on my fork and found it works now as expected https://yuzie007.github.io/motep/optimizers/linear.html.