### PR TITLE
Update the version scheme of `setuptools_scm` to be PyPI compliant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ motep = "motep.__init__:main"
 find = {}
 
 [tool.setuptools_scm]
+version_scheme = "no-guess-dev"
+local_scheme = "no-local-version"
 
 [tool.ruff.lint]
 preview = true  # necessary to activate many pycodestyle rules


### PR DESCRIPTION
# Summary

This PR updates the version scheme of `setuptools_scm` to be PyPI compliant.

# Details

Presently we use `setuptools_scm` to assign a dev version number automatically. We can see the actual present version with
```bash
python -m setuptools_scm
```
For the present master, this gives
```
0.1.dev781+g020736a
```

While this would be nice as it assigns really unique versions based on the Git commit, this cannot be directly uploaded to PyPI (see [here](https://setuptools-scm.readthedocs.io/en/latest/integrations/#cicd-and-package-publishing)). To solve this, [there are several available options for the version scheme.](https://setuptools-scm.readthedocs.io/en/latest/extending/#version-number-construction) Particularly with the following setting:
```toml
[tool.setuptools_scm]
version_scheme = "no-guess-dev"
local_scheme = "no-local-version"
```
which gives
```
0.0.post1.dev782
```
[This is what I actually used in `mpitern`](https://github.com/yuzie007/mpltern/blob/1.0.4/pyproject.toml#L4-L6), so I am almost sure this works.