### PR TITLE
Add option to consider `species_coeffs` and `radial_coeffs` for grading

### DIFF
--- a/motep/grade/grader.py
+++ b/motep/grade/grader.py
@@ -87,13 +87,14 @@ class Grader:
             List of ASE Atoms objects to evaluate. Modified in-place.
 
         """
+        mode = "train" if "radial_coeffs" in self.mtp_data.optimized else "run"
         for atoms in images:
             if atoms.calc is not None and "magmoms" in atoms.calc.results:
                 atoms.set_initial_magnetic_moments(atoms.calc.results["magmoms"])
             atoms.calc = make_calculator(
                 self.mtp_data,
                 engine=self.engine,
-                mode="run",
+                mode=mode,
                 relax_magmoms=False,
             )
             atoms.get_potential_energy()

--- a/motep/grade/grader.py
+++ b/motep/grade/grader.py
@@ -72,7 +72,7 @@ class Grader:
         """
         images = [copy(_) for _ in images]
         self._evaluate(images)
-        matrix = self._calc_moment_basis_matrix(images)
+        matrix = self._calc_jacobian(images)
         self.maxvol_result = self.maxvol.run(matrix)
 
     def _evaluate(self, images: list[Atoms]) -> None:
@@ -98,8 +98,8 @@ class Grader:
             )
             atoms.get_potential_energy()
 
-    def _calc_moment_basis_matrix(self, images: list[Atoms]) -> np.ndarray:
-        """Calculate the matrix of moment basis values.
+    def _calc_jacobian(self, images: list[Atoms]) -> np.ndarray:
+        """Calculate the Jacobian of energies with respect to the parameters.
 
         Parameters
         ----------
@@ -109,7 +109,8 @@ class Grader:
 
         Returns
         -------
-        moment_basis_matrix : np.ndarray
+        np.ndarray
+            Jacobian.
 
         Raises
         ------
@@ -158,7 +159,7 @@ class Grader:
         """
         images = [copy(_) for _ in images]
         self._evaluate(images)
-        matrix = self._calc_moment_basis_matrix(images)
+        matrix = self._calc_jacobian(images)
 
         active_set_matrix = self.maxvol_result.submatrix
 

--- a/motep/grade/grader.py
+++ b/motep/grade/grader.py
@@ -218,7 +218,6 @@ def grade_from_setting(filename_setting: str, comm: DummyMPIComm) -> None:
         species = get_dummy_species(images_training)
 
     mtp_data = read_mtp(mtp_file)
-    mtp_data.optimized = ["moment_coeffs"]
     mtp_data.species = species
 
     if setting.common.engine == "mlippy":

--- a/motep/grade/grader.py
+++ b/motep/grade/grader.py
@@ -117,7 +117,12 @@ class Grader:
 
         """
         if self.mode == GradeMode.CONFIGURATION:
-            return np.array([atoms.calc.engine.mbd.values for atoms in images])
+
+            def fcnf(atoms: Atoms) -> np.ndarray:
+                return atoms.calc.engine.jac_energy(atoms).parameters
+
+            return np.array([fcnf(atoms) for atoms in images])
+
         if self.mode == GradeMode.NEIGHBORHOOD:
             return np.vstack([atoms.calc.engine.mbd.vatoms.T for atoms in images])
         raise ValueError(self.mode)

--- a/motep/grade/grader.py
+++ b/motep/grade/grader.py
@@ -124,7 +124,12 @@ class Grader:
             return np.array([fcnf(atoms) for atoms in images])
 
         if self.mode == GradeMode.NEIGHBORHOOD:
-            return np.vstack([atoms.calc.engine.mbd.vatoms.T for atoms in images])
+
+            def fnbh(atoms: Atoms) -> np.ndarray:
+                return atoms.calc.engine.jac_energies(atoms).parameters.T
+
+            return np.vstack([fnbh(atoms) for atoms in images])
+
         raise ValueError(self.mode)
 
     def grade(self, images: list[Atoms]) -> list[Atoms]:
@@ -213,6 +218,7 @@ def grade_from_setting(filename_setting: str, comm: DummyMPIComm) -> None:
         species = get_dummy_species(images_training)
 
     mtp_data = read_mtp(mtp_file)
+    mtp_data.optimized = ["moment_coeffs"]
     mtp_data.species = species
 
     if setting.common.engine == "mlippy":

--- a/motep/potentials/mmtp/base.py
+++ b/motep/potentials/mmtp/base.py
@@ -40,7 +40,7 @@ class MagMomentBasisData(MagModeBase, MomentBasisData):
         if "train" in self.mode:
             self.dbdris = np.full((asm, natoms, 3), np.nan)
             self.dbdeps = np.full((asm, 3, 3), np.nan)
-            self.dedcs = np.full((spc, spc, rfc, nrb), np.nan)
+            self.dvdcs = np.full((spc, spc, rfc, nrb, natoms), np.nan)
             self.dgdcs = np.full((spc, spc, rfc, nrb, natoms, 3), np.nan)
             self.dsdcs = np.full((spc, spc, rfc, nrb, 3, 3), np.nan)
 

--- a/motep/potentials/mmtp/cext/mmtp_cext.c
+++ b/motep/potentials/mmtp/cext/mmtp_cext.c
@@ -262,7 +262,7 @@ void calc_mag_train(
     double *mbd_vatoms,
     double *mbd_dbdris,
     double *mbd_dbdeps,
-    double *mbd_dedcs,
+    double *mbd_dvdcs,
     double *mbd_dgdcs,
     double *mbd_dsdcs)
 {
@@ -377,15 +377,17 @@ void calc_mag_train(
             dedmb,
             dgdmb);
 
-        accumulate_mbd_dedcs(
+        accumulate_mbd_dvdcs(
+            i,
             itype,
+            n_atoms,
             n_basic,
             species_count,
             radial_funcs_count,
             nrb,
             moment_jac_cs,
             dedmb,
-            mbd_dedcs);
+            mbd_dvdcs);
 
         accumulate_mbd_dgdcs_dsdcs(
             i,
@@ -480,7 +482,7 @@ void calc_mag_train_mgrad(
     double *mbd_dbdris,
     double *mbd_dbdmis,
     double *mbd_dbdeps,
-    double *mbd_dedcs,
+    double *mbd_dvdcs,
     double *mbd_dgdcs,
     double *mbd_dgmdcs,
     double *mbd_dsdcs)
@@ -628,15 +630,17 @@ void calc_mag_train_mgrad(
             dgmidmb,
             dgmjdmb);
 
-        accumulate_mbd_dedcs(
+        accumulate_mbd_dvdcs(
+            i,
             itype,
+            n_atoms,
             n_basic,
             species_count,
             radial_funcs_count,
             nrb,
             moment_jac_cs,
             dedmb,
-            mbd_dedcs);
+            mbd_dvdcs);
 
         accumulate_mbd_dgdcs_dsdcs(
             i,

--- a/motep/potentials/mmtp/cext/mmtp_cext.h
+++ b/motep/potentials/mmtp/cext/mmtp_cext.h
@@ -79,7 +79,7 @@ void calc_mag_train(
     double *mbd_vatoms,
     double *mbd_dbdris,
     double *mbd_dbdeps,
-    double *mbd_dedcs,
+    double *mbd_dvdcs,
     double *mbd_dgdcs,
     double *mbd_dsdcs);
 
@@ -115,7 +115,7 @@ void calc_mag_train_mgrad(
     double *mbd_dbdris,
     double *mbd_dbdmis,
     double *mbd_dbdeps,
-    double *mbd_dedcs,
+    double *mbd_dvdcs,
     double *mbd_dgdcs,
     double *mbd_dgmdcs,
     double *mbd_dsdcs);

--- a/motep/potentials/mmtp/cext/mmtp_cext_module.c
+++ b/motep/potentials/mmtp/cext/mmtp_cext_module.c
@@ -544,19 +544,19 @@ static PyObject *py_calc_mag_train(PyObject *self, PyObject *args, PyObject *kwa
     PyObject *mbd_vatoms_obj = PyObject_GetAttrString(mbd_obj, "vatoms");
     PyObject *mbd_dbdris_obj = PyObject_GetAttrString(mbd_obj, "dbdris");
     PyObject *mbd_dbdeps_obj = PyObject_GetAttrString(mbd_obj, "dbdeps");
-    PyObject *mbd_dedcs_obj = PyObject_GetAttrString(mbd_obj, "dedcs");
+    PyObject *mbd_dvdcs_obj = PyObject_GetAttrString(mbd_obj, "dvdcs");
     PyObject *mbd_dgdcs_obj = PyObject_GetAttrString(mbd_obj, "dgdcs");
     PyObject *mbd_dsdcs_obj = PyObject_GetAttrString(mbd_obj, "dsdcs");
     PyArrayObject *mbd_vatoms_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_vatoms_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
     PyArrayObject *mbd_dbdris_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dbdris_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
     PyArrayObject *mbd_dbdeps_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dbdeps_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dedcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dedcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
+    PyArrayObject *mbd_dvdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dvdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
     PyArrayObject *mbd_dgdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dgdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
     PyArrayObject *mbd_dsdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dsdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
 
     if (!rbd_values_arr || !rbd_dqdris_arr || !rbd_dqdeps_arr ||
         !mbd_vatoms_arr || !mbd_dbdris_arr || !mbd_dbdeps_arr ||
-        !mbd_dedcs_arr || !mbd_dgdcs_arr || !mbd_dsdcs_arr)
+        !mbd_dvdcs_arr || !mbd_dgdcs_arr || !mbd_dsdcs_arr)
     {
         Py_DECREF(radial_coeffs_arr);
         Py_DECREF(species_coeffs_arr);
@@ -571,7 +571,7 @@ static PyObject *py_calc_mag_train(PyObject *self, PyObject *args, PyObject *kwa
         Py_XDECREF(mbd_vatoms_arr);
         Py_XDECREF(mbd_dbdris_arr);
         Py_XDECREF(mbd_dbdeps_arr);
-        Py_XDECREF(mbd_dedcs_arr);
+        Py_XDECREF(mbd_dvdcs_arr);
         Py_XDECREF(mbd_dgdcs_arr);
         Py_XDECREF(mbd_dsdcs_arr);
         return NULL;
@@ -583,7 +583,7 @@ static PyObject *py_calc_mag_train(PyObject *self, PyObject *args, PyObject *kwa
         !require_inplace_double(mbd_vatoms_arr, "mbd.vatoms") ||
         !require_inplace_double(mbd_dbdris_arr, "mbd.dbdris") ||
         !require_inplace_double(mbd_dbdeps_arr, "mbd.dbdeps") ||
-        !require_inplace_double(mbd_dedcs_arr, "mbd.dedcs") ||
+        !require_inplace_double(mbd_dvdcs_arr, "mbd.dvdcs") ||
         !require_inplace_double(mbd_dgdcs_arr, "mbd.dgdcs") ||
         !require_inplace_double(mbd_dsdcs_arr, "mbd.dsdcs"))
     {
@@ -599,7 +599,7 @@ static PyObject *py_calc_mag_train(PyObject *self, PyObject *args, PyObject *kwa
         Py_DECREF(mbd_vatoms_arr);
         Py_DECREF(mbd_dbdris_arr);
         Py_DECREF(mbd_dbdeps_arr);
-        Py_DECREF(mbd_dedcs_arr);
+        Py_DECREF(mbd_dvdcs_arr);
         Py_DECREF(mbd_dgdcs_arr);
         Py_DECREF(mbd_dsdcs_arr);
         Py_XDECREF(radial_basis_size_obj);
@@ -623,7 +623,7 @@ static PyObject *py_calc_mag_train(PyObject *self, PyObject *args, PyObject *kwa
         Py_DECREF(mbd_vatoms_arr);
         Py_DECREF(mbd_dbdris_arr);
         Py_DECREF(mbd_dbdeps_arr);
-        Py_DECREF(mbd_dedcs_arr);
+        Py_DECREF(mbd_dvdcs_arr);
         Py_DECREF(mbd_dgdcs_arr);
         Py_DECREF(mbd_dsdcs_arr);
         return NULL;
@@ -658,7 +658,7 @@ static PyObject *py_calc_mag_train(PyObject *self, PyObject *args, PyObject *kwa
         (double *)PyArray_DATA(mbd_vatoms_arr),
         (double *)PyArray_DATA(mbd_dbdris_arr),
         (double *)PyArray_DATA(mbd_dbdeps_arr),
-        (double *)PyArray_DATA(mbd_dedcs_arr),
+        (double *)PyArray_DATA(mbd_dvdcs_arr),
         (double *)PyArray_DATA(mbd_dgdcs_arr),
         (double *)PyArray_DATA(mbd_dsdcs_arr));
 
@@ -674,7 +674,7 @@ static PyObject *py_calc_mag_train(PyObject *self, PyObject *args, PyObject *kwa
     Py_DECREF(mbd_vatoms_arr);
     Py_DECREF(mbd_dbdris_arr);
     Py_DECREF(mbd_dbdeps_arr);
-    Py_DECREF(mbd_dedcs_arr);
+    Py_DECREF(mbd_dvdcs_arr);
     Py_DECREF(mbd_dgdcs_arr);
     Py_DECREF(mbd_dsdcs_arr);
     Py_DECREF(scaling_obj);
@@ -698,7 +698,7 @@ static PyObject *py_calc_mag_train(PyObject *self, PyObject *args, PyObject *kwa
     Py_DECREF(mbd_vatoms_obj);
     Py_DECREF(mbd_dbdris_obj);
     Py_DECREF(mbd_dbdeps_obj);
-    Py_DECREF(mbd_dedcs_obj);
+    Py_DECREF(mbd_dvdcs_obj);
     Py_DECREF(mbd_dgdcs_obj);
     Py_DECREF(mbd_dsdcs_obj);
     Py_DECREF(radial_coeffs_obj);
@@ -884,7 +884,7 @@ static PyObject *py_calc_mag_train_mgrad(PyObject *self, PyObject *args, PyObjec
     PyObject *mbd_dbdris_obj = PyObject_GetAttrString(mbd_obj, "dbdris");
     PyObject *mbd_dbdmis_obj = PyObject_GetAttrString(mbd_obj, "dbdmis");
     PyObject *mbd_dbdeps_obj = PyObject_GetAttrString(mbd_obj, "dbdeps");
-    PyObject *mbd_dedcs_obj = PyObject_GetAttrString(mbd_obj, "dedcs");
+    PyObject *mbd_dvdcs_obj = PyObject_GetAttrString(mbd_obj, "dvdcs");
     PyObject *mbd_dgdcs_obj = PyObject_GetAttrString(mbd_obj, "dgdcs");
     PyObject *mbd_dgmdcs_obj = PyObject_GetAttrString(mbd_obj, "dgmdcs");
     PyObject *mbd_dsdcs_obj = PyObject_GetAttrString(mbd_obj, "dsdcs");
@@ -892,14 +892,14 @@ static PyObject *py_calc_mag_train_mgrad(PyObject *self, PyObject *args, PyObjec
     PyArrayObject *mbd_dbdris_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dbdris_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
     PyArrayObject *mbd_dbdmis_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dbdmis_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
     PyArrayObject *mbd_dbdeps_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dbdeps_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dedcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dedcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
+    PyArrayObject *mbd_dvdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dvdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
     PyArrayObject *mbd_dgdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dgdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
     PyArrayObject *mbd_dgmdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dgmdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
     PyArrayObject *mbd_dsdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dsdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
 
     if (!rbd_values_arr || !rbd_dqdris_arr || !rbd_dqdmis_arr || !rbd_dqdeps_arr ||
         !mbd_vatoms_arr || !mbd_dbdris_arr || !mbd_dbdmis_arr || !mbd_dbdeps_arr ||
-        !mbd_dedcs_arr || !mbd_dgdcs_arr || !mbd_dgmdcs_arr || !mbd_dsdcs_arr)
+        !mbd_dvdcs_arr || !mbd_dgdcs_arr || !mbd_dgmdcs_arr || !mbd_dsdcs_arr)
     {
         Py_DECREF(radial_coeffs_arr);
         Py_DECREF(species_coeffs_arr);
@@ -916,7 +916,7 @@ static PyObject *py_calc_mag_train_mgrad(PyObject *self, PyObject *args, PyObjec
         Py_XDECREF(mbd_dbdris_arr);
         Py_XDECREF(mbd_dbdmis_arr);
         Py_XDECREF(mbd_dbdeps_arr);
-        Py_XDECREF(mbd_dedcs_arr);
+        Py_XDECREF(mbd_dvdcs_arr);
         Py_XDECREF(mbd_dgdcs_arr);
         Py_XDECREF(mbd_dgmdcs_arr);
         Py_XDECREF(mbd_dsdcs_arr);
@@ -931,7 +931,7 @@ static PyObject *py_calc_mag_train_mgrad(PyObject *self, PyObject *args, PyObjec
         !require_inplace_double(mbd_dbdris_arr, "mbd.dbdris") ||
         !require_inplace_double(mbd_dbdmis_arr, "mbd.dbdmis") ||
         !require_inplace_double(mbd_dbdeps_arr, "mbd.dbdeps") ||
-        !require_inplace_double(mbd_dedcs_arr, "mbd.dedcs") ||
+        !require_inplace_double(mbd_dvdcs_arr, "mbd.dvdcs") ||
         !require_inplace_double(mbd_dgdcs_arr, "mbd.dgdcs") ||
         !require_inplace_double(mbd_dgmdcs_arr, "mbd.dgmdcs") ||
         !require_inplace_double(mbd_dsdcs_arr, "mbd.dsdcs"))
@@ -950,7 +950,7 @@ static PyObject *py_calc_mag_train_mgrad(PyObject *self, PyObject *args, PyObjec
         Py_DECREF(mbd_dbdris_arr);
         Py_DECREF(mbd_dbdmis_arr);
         Py_DECREF(mbd_dbdeps_arr);
-        Py_DECREF(mbd_dedcs_arr);
+        Py_DECREF(mbd_dvdcs_arr);
         Py_DECREF(mbd_dgdcs_arr);
         Py_DECREF(mbd_dgmdcs_arr);
         Py_DECREF(mbd_dsdcs_arr);
@@ -977,7 +977,7 @@ static PyObject *py_calc_mag_train_mgrad(PyObject *self, PyObject *args, PyObjec
         Py_DECREF(mbd_dbdris_arr);
         Py_DECREF(mbd_dbdmis_arr);
         Py_DECREF(mbd_dbdeps_arr);
-        Py_DECREF(mbd_dedcs_arr);
+        Py_DECREF(mbd_dvdcs_arr);
         Py_DECREF(mbd_dgdcs_arr);
         Py_DECREF(mbd_dgmdcs_arr);
         Py_DECREF(mbd_dsdcs_arr);
@@ -1015,7 +1015,7 @@ static PyObject *py_calc_mag_train_mgrad(PyObject *self, PyObject *args, PyObjec
         (double *)PyArray_DATA(mbd_dbdris_arr),
         (double *)PyArray_DATA(mbd_dbdmis_arr),
         (double *)PyArray_DATA(mbd_dbdeps_arr),
-        (double *)PyArray_DATA(mbd_dedcs_arr),
+        (double *)PyArray_DATA(mbd_dvdcs_arr),
         (double *)PyArray_DATA(mbd_dgdcs_arr),
         (double *)PyArray_DATA(mbd_dgmdcs_arr),
         (double *)PyArray_DATA(mbd_dsdcs_arr));
@@ -1034,7 +1034,7 @@ static PyObject *py_calc_mag_train_mgrad(PyObject *self, PyObject *args, PyObjec
     Py_DECREF(mbd_dbdris_arr);
     Py_DECREF(mbd_dbdmis_arr);
     Py_DECREF(mbd_dbdeps_arr);
-    Py_DECREF(mbd_dedcs_arr);
+    Py_DECREF(mbd_dvdcs_arr);
     Py_DECREF(mbd_dgdcs_arr);
     Py_DECREF(mbd_dgmdcs_arr);
     Py_DECREF(mbd_dsdcs_arr);
@@ -1061,7 +1061,7 @@ static PyObject *py_calc_mag_train_mgrad(PyObject *self, PyObject *args, PyObjec
     Py_DECREF(mbd_dbdris_obj);
     Py_DECREF(mbd_dbdmis_obj);
     Py_DECREF(mbd_dbdeps_obj);
-    Py_DECREF(mbd_dedcs_obj);
+    Py_DECREF(mbd_dvdcs_obj);
     Py_DECREF(mbd_dgdcs_obj);
     Py_DECREF(mbd_dgmdcs_obj);
     Py_DECREF(mbd_dsdcs_obj);

--- a/motep/potentials/mtp/base.py
+++ b/motep/potentials/mtp/base.py
@@ -45,6 +45,8 @@ class MomentBasisData(ModeBase):
         This corresponds to nabla b_j in Eq. (7a) in [Podryabinkin_CMS_2017_Active]_.
     dbdeps : np.ndarray (alpha_moments_count, 3, 3)
         Derivatives of cumulated basis functions with respect to the strain tensor.
+    dvdcs: np.ndarray
+        Derivatives of local energies with respect to the radial coefficients.
 
     .. [Podryabinkin_CMS_2017_Active]
        E. V. Podryabinkin and A. V. Shapeev, Comput. Mater. Sci. 140, 171 (2017).
@@ -56,7 +58,7 @@ class MomentBasisData(ModeBase):
     vatoms: npt.NDArray[np.float64] = field(default_factory=lambda: np.array(np.nan))
     dbdris: npt.NDArray[np.float64] = field(default_factory=lambda: np.array(np.nan))
     dbdeps: npt.NDArray[np.float64] = field(default_factory=lambda: np.array(np.nan))
-    dedcs: npt.NDArray[np.float64] = field(default_factory=lambda: np.array(np.nan))
+    dvdcs: npt.NDArray[np.float64] = field(default_factory=lambda: np.array(np.nan))
     dgdcs: npt.NDArray[np.float64] = field(default_factory=lambda: np.array(np.nan))
     dsdcs: npt.NDArray[np.float64] = field(default_factory=lambda: np.array(np.nan))
 
@@ -64,6 +66,11 @@ class MomentBasisData(ModeBase):
     def values(self) -> np.ndarray:
         """Basis values summed over atoms."""
         return self.vatoms.sum(axis=-1)
+
+    @property
+    def dedcs(self) -> np.ndarray:
+        """Derivatives of local energies with respect to the radial coefficients."""
+        return self.dvdcs.sum(axis=-1)
 
     def initialize(self, natoms: int, mtp_data: MTPData) -> None:
         """Initialize moment basis properties."""
@@ -76,7 +83,7 @@ class MomentBasisData(ModeBase):
         if "train" in self.mode:
             self.dbdris = np.full((asm, natoms, 3), np.nan)
             self.dbdeps = np.full((asm, 3, 3), np.nan)
-            self.dedcs = np.full((spc, spc, rfc, rbs), np.nan)
+            self.dvdcs = np.full((spc, spc, rfc, rbs, natoms), np.nan)
             self.dgdcs = np.full((spc, spc, rfc, rbs, natoms, 3), np.nan)
             self.dsdcs = np.full((spc, spc, rfc, rbs, 3, 3), np.nan)
 
@@ -86,7 +93,7 @@ class MomentBasisData(ModeBase):
         if "train" in self.mode:
             self.dbdris[...] = 0.0
             self.dbdeps[...] = 0.0
-            self.dedcs[...] = 0.0
+            self.dvdcs[...] = 0.0
             self.dgdcs[...] = 0.0
             self.dsdcs[...] = 0.0
 
@@ -347,7 +354,14 @@ class EngineBase(EngineWithNeighborlist):
                 self.rbd.dqdeps[:, :, :] = np.nan
 
     def jac_energy(self, atoms: Atoms) -> MTPData:
-        """Calculate the Jacobian of the energy with respect to the MTP parameters."""
+        """Calculate the Jacobian of the energy with respect to the MTP parameters.
+
+        Returns
+        -------
+        MTPData
+            Placeholder of the Jacobian of the energy with respect tothe MTP parameters.
+
+        """
         sps = self.mtp_data.species
         nbs = list(atoms.numbers)
 

--- a/motep/potentials/mtp/base.py
+++ b/motep/potentials/mtp/base.py
@@ -374,6 +374,28 @@ class EngineBase(EngineWithNeighborlist):
         jac.optimized = self.mtp_data.optimized
         return jac
 
+    def jac_energies(self, atoms: Atoms) -> Jacobian:
+        """Calculate the Jacobian of local energies with respect to the MTP parameters.
+
+        Returns
+        -------
+        Jacobian
+            Jacobian whose ``parameters`` have the shape of `(nparams, natoms)`.
+
+        """
+        number_of_atoms = len(atoms)
+        spicies_coeffs = np.full((self.mtp_data.species_count, number_of_atoms), np.nan)
+        for i, s in enumerate(self.mtp_data.species):
+            spicies_coeffs[i] = atoms.numbers == s
+
+        return Jacobian(
+            scaling=np.zeros((1, number_of_atoms)),
+            moment_coeffs=self.mbd.vatoms,
+            species_coeffs=spicies_coeffs,
+            radial_coeffs=self.mbd.dvdcs,
+            optimized=self.mtp_data.optimized,
+        )
+
     def jac_forces(self, atoms: Atoms) -> Jacobian:
         """Calculate the Jacobian of the forces with respect to the MTP parameters.
 

--- a/motep/potentials/mtp/cext/engine.py
+++ b/motep/potentials/mtp/cext/engine.py
@@ -9,10 +9,11 @@ from motep.potentials.mtp.data import get_types
 try:
     from motep.potentials.mtp.cext import _mtp_cext
 except ImportError as e:
-    raise ImportError(
+    msg = (
         "C extension module '_mtp_cext' not found. "
         "Please build the extension with: pip install -e ."
-    ) from e
+    )
+    raise ImportError(msg) from e
 
 
 class CExtMTPEngine(EngineBase):
@@ -26,7 +27,7 @@ class CExtMTPEngine(EngineBase):
         """Initialize the engine."""
         super().__init__(*args, **kwargs)
 
-    def _calculate(self, atoms: Atoms) -> tuple:
+    def _calculate(self, atoms: Atoms) -> tuple[np.ndarray, ...]:
         """Main calculation dispatch."""
         if self.mode == "run":
             return self._calc_run(atoms)
@@ -34,8 +35,14 @@ class CExtMTPEngine(EngineBase):
             return self._calc_train(atoms)
         raise NotImplementedError(self.mode)
 
-    def _calc_run(self, atoms: Atoms) -> tuple:
-        """Calculate energies, forces, and stress for run mode."""
+    def _calc_run(self, atoms: Atoms) -> tuple[np.ndarray, ...]:
+        """Calculate energies, forces, and stress for run mode.
+
+        Returns
+        -------
+        tuple[np.ndarray, ...]
+
+        """
         mtp_data = self.mtp_data
 
         all_js = self._neighbors
@@ -61,8 +68,14 @@ class CExtMTPEngine(EngineBase):
 
         return energies, forces, stress
 
-    def _calc_train(self, atoms: Atoms) -> tuple:
-        """Calculate energies, forces, and stress for training mode."""
+    def _calc_train(self, atoms: Atoms) -> tuple[np.ndarray, ...]:
+        """Calculate energies, forces, and stress for training mode.
+
+        Returns
+        -------
+        tuple[np.ndarray, ...]
+
+        """
         mtp_data = self.mtp_data
 
         js = self._neighbors

--- a/motep/potentials/mtp/cext/mtp_cext.c
+++ b/motep/potentials/mtp/cext/mtp_cext.c
@@ -324,17 +324,19 @@ void calc_train(
             dgdmb);
 
         /* ====================================================================
-         * Step 6b: Accumulate dedcs from basic moment jacobians
+         * Step 6b: Accumulate dvdcs from basic moment jacobians
          * ==================================================================== */
-        accumulate_mbd_dedcs(
+        accumulate_mbd_dvdcs(
+            i,
             itype,
+            n_atoms,
             n_basic,
             species_count,
             radial_funcs_count,
             rbs,
             moment_jac_cs,
             dedmb,
-            mbd->dedcs);
+            mbd->dvdcs);
 
         /* ====================================================================
          * Step 6c: Accumulate dgdcs from basic moment jacobians

--- a/motep/potentials/mtp/cext/mtp_cext.h
+++ b/motep/potentials/mtp/cext/mtp_cext.h
@@ -24,7 +24,7 @@ typedef struct
     double *vatoms; /* (alpha_scalar_moments, n_atoms) */
     double *dbdris; /* (alpha_scalar_moments, n_atoms, 3) */
     double *dbdeps; /* (alpha_scalar_moments, 3, 3) */
-    double *dedcs;  /* (species_count, species_count, radial_funcs_count, radial_basis_size) */
+    double *dvdcs;  /* (species_count, species_count, radial_funcs_count, radial_basis_size, n_atoms) */
     double *dgdcs;  /* (species_count, species_count, radial_funcs_count, radial_basis_size, n_atoms, 3) */
     double *dsdcs;  /* (species_count, species_count, radial_funcs_count, radial_basis_size, 3, 3) */
 } MomentBasisData;

--- a/motep/potentials/mtp/cext/mtp_cext_kernels.h
+++ b/motep/potentials/mtp/cext/mtp_cext_kernels.h
@@ -526,17 +526,19 @@ static inline void accumulate_mbd_dgdcs_dsdcs(
 }
 
 /* ==========================================================================
- * Accumulate mbd.dedcs from basic moment jacobians
+ * Accumulate mbd.dvdcs from basic moment jacobians
  * ========================================================================== */
-static inline void accumulate_mbd_dedcs(
+static inline void accumulate_mbd_dvdcs(
+    int i,
     int itype,
+    int n_atoms,
     int n_basic,
     int species_count,
     int radial_funcs_count,
     int radial_basis_size,
     const double *moment_jac_cs,
     const double *dedmb,
-    double *dedcs)
+    double *dvdcs)
 {
     int rbs = radial_basis_size;
     int rfc = radial_funcs_count;
@@ -554,8 +556,8 @@ static inline void accumulate_mbd_dedcs(
                     int mjac_idx = ((iamc * species_count + jtype_idx) * rfc + irf) * rbs + irb;
                     double mjac_val = moment_jac_cs[mjac_idx];
 
-                    int dedcs_idx = ((itype * species_count + jtype_idx) * rfc + irf) * rbs + irb;
-                    dedcs[dedcs_idx] += mjac_val * v1;
+                    int dvdcs_idx = (((itype * species_count + jtype_idx) * rfc + irf) * rbs + irb) * n_atoms + i;
+                    dvdcs[dvdcs_idx] += mjac_val * v1;
                 }
             }
         }

--- a/motep/potentials/mtp/cext/mtp_cext_module.c
+++ b/motep/potentials/mtp/cext/mtp_cext_module.c
@@ -413,13 +413,13 @@ static PyObject *py_calc_train(PyObject *self, PyObject *args, PyObject *kwargs)
     PyObject *mbd_vatoms_obj = PyObject_GetAttrString(mbd_obj, "vatoms");
     PyObject *mbd_dbdris_obj = PyObject_GetAttrString(mbd_obj, "dbdris");
     PyObject *mbd_dbdeps_obj = PyObject_GetAttrString(mbd_obj, "dbdeps");
-    PyObject *mbd_dedcs_obj = PyObject_GetAttrString(mbd_obj, "dedcs");
+    PyObject *mbd_dvdcs_obj = PyObject_GetAttrString(mbd_obj, "dvdcs");
     PyObject *mbd_dgdcs_obj = PyObject_GetAttrString(mbd_obj, "dgdcs");
     PyObject *mbd_dsdcs_obj = PyObject_GetAttrString(mbd_obj, "dsdcs");
 
     if (!rbd_values_obj || !rbd_dqdris_obj || !rbd_dqdeps_obj ||
         !mbd_vatoms_obj || !mbd_dbdris_obj || !mbd_dbdeps_obj ||
-        !mbd_dedcs_obj || !mbd_dgdcs_obj || !mbd_dsdcs_obj)
+        !mbd_dvdcs_obj || !mbd_dgdcs_obj || !mbd_dsdcs_obj)
     {
         Py_DECREF(radial_coeffs_arr);
         Py_DECREF(species_coeffs_arr);
@@ -438,13 +438,13 @@ static PyObject *py_calc_train(PyObject *self, PyObject *args, PyObject *kwargs)
     PyArrayObject *mbd_vatoms_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_vatoms_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
     PyArrayObject *mbd_dbdris_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dbdris_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
     PyArrayObject *mbd_dbdeps_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dbdeps_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dedcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dedcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
+    PyArrayObject *mbd_dvdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dvdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
     PyArrayObject *mbd_dgdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dgdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
     PyArrayObject *mbd_dsdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dsdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
 
     if (!rbd_values_arr || !rbd_dqdris_arr || !rbd_dqdeps_arr ||
         !mbd_vatoms_arr || !mbd_dbdris_arr || !mbd_dbdeps_arr ||
-        !mbd_dedcs_arr || !mbd_dgdcs_arr || !mbd_dsdcs_arr)
+        !mbd_dvdcs_arr || !mbd_dgdcs_arr || !mbd_dsdcs_arr)
     {
         Py_DECREF(radial_coeffs_arr);
         Py_DECREF(species_coeffs_arr);
@@ -458,7 +458,7 @@ static PyObject *py_calc_train(PyObject *self, PyObject *args, PyObject *kwargs)
         Py_XDECREF(mbd_vatoms_arr);
         Py_XDECREF(mbd_dbdris_arr);
         Py_XDECREF(mbd_dbdeps_arr);
-        Py_XDECREF(mbd_dedcs_arr);
+        Py_XDECREF(mbd_dvdcs_arr);
         Py_XDECREF(mbd_dgdcs_arr);
         Py_XDECREF(mbd_dsdcs_arr);
         Py_DECREF(energies_arr);
@@ -471,7 +471,7 @@ static PyObject *py_calc_train(PyObject *self, PyObject *args, PyObject *kwargs)
         !require_inplace_double(mbd_vatoms_arr, "mbd.vatoms") ||
         !require_inplace_double(mbd_dbdris_arr, "mbd.dbdris") ||
         !require_inplace_double(mbd_dbdeps_arr, "mbd.dbdeps") ||
-        !require_inplace_double(mbd_dedcs_arr, "mbd.dedcs") ||
+        !require_inplace_double(mbd_dvdcs_arr, "mbd.dvdcs") ||
         !require_inplace_double(mbd_dgdcs_arr, "mbd.dgdcs") ||
         !require_inplace_double(mbd_dsdcs_arr, "mbd.dsdcs"))
     {
@@ -487,7 +487,7 @@ static PyObject *py_calc_train(PyObject *self, PyObject *args, PyObject *kwargs)
         Py_DECREF(mbd_vatoms_arr);
         Py_DECREF(mbd_dbdris_arr);
         Py_DECREF(mbd_dbdeps_arr);
-        Py_DECREF(mbd_dedcs_arr);
+        Py_DECREF(mbd_dvdcs_arr);
         Py_DECREF(mbd_dgdcs_arr);
         Py_DECREF(mbd_dsdcs_arr);
         Py_DECREF(energies_arr);
@@ -504,7 +504,7 @@ static PyObject *py_calc_train(PyObject *self, PyObject *args, PyObject *kwargs)
         .vatoms = (double *)PyArray_DATA(mbd_vatoms_arr),
         .dbdris = (double *)PyArray_DATA(mbd_dbdris_arr),
         .dbdeps = (double *)PyArray_DATA(mbd_dbdeps_arr),
-        .dedcs = (double *)PyArray_DATA(mbd_dedcs_arr),
+        .dvdcs = (double *)PyArray_DATA(mbd_dvdcs_arr),
         .dgdcs = (double *)PyArray_DATA(mbd_dgdcs_arr),
         .dsdcs = (double *)PyArray_DATA(mbd_dsdcs_arr)};
 
@@ -545,7 +545,7 @@ static PyObject *py_calc_train(PyObject *self, PyObject *args, PyObject *kwargs)
     Py_DECREF(mbd_vatoms_arr);
     Py_DECREF(mbd_dbdris_arr);
     Py_DECREF(mbd_dbdeps_arr);
-    Py_DECREF(mbd_dedcs_arr);
+    Py_DECREF(mbd_dvdcs_arr);
     Py_DECREF(mbd_dgdcs_arr);
     Py_DECREF(mbd_dsdcs_arr);
     Py_DECREF(scaling_obj);
@@ -567,7 +567,7 @@ static PyObject *py_calc_train(PyObject *self, PyObject *args, PyObject *kwargs)
     Py_DECREF(mbd_vatoms_obj);
     Py_DECREF(mbd_dbdris_obj);
     Py_DECREF(mbd_dbdeps_obj);
-    Py_DECREF(mbd_dedcs_obj);
+    Py_DECREF(mbd_dvdcs_obj);
     Py_DECREF(mbd_dgdcs_obj);
     Py_DECREF(mbd_dsdcs_obj);
 

--- a/motep/potentials/mtp/numba/engine.py
+++ b/motep/potentials/mtp/numba/engine.py
@@ -15,9 +15,9 @@ from .moment import (
     store_radial_basis,
     update_mbd_dbdeps,
     update_mbd_dbdris,
-    update_mbd_dedcs,
     update_mbd_dgdcs,
     update_mbd_dsdcs,
+    update_mbd_dvdcs,
     update_mbd_vatoms,
 )
 
@@ -103,7 +103,7 @@ class NumbaMTPEngine(EngineBase):
             self.mbd.vatoms,
             self.mbd.dbdris,
             self.mbd.dbdeps,
-            self.mbd.dedcs,
+            self.mbd.dvdcs,
             self.mbd.dgdcs,
             self.mbd.dsdcs,
         )
@@ -233,7 +233,7 @@ def _calc_run(
         nb.float64[:, :],  # mbd_vatoms
         nb.float64[:, :, :],
         nb.float64[:, :, :],
-        nb.float64[:, :, :, :],
+        nb.float64[:, :, :, :, :],  # mbd_dvdcs
         nb.float64[:, :, :, :, :, :],
         nb.float64[:, :, :, :, :, :],
     ),
@@ -260,7 +260,7 @@ def _calc_train(
     mbd_vatoms: npt.NDArray[np.float64],
     mbd_dbdris: npt.NDArray[np.float64],
     mbd_dbdeps: npt.NDArray[np.float64],
-    mbd_dedcs: npt.NDArray[np.float64],
+    mbd_dvdcs: npt.NDArray[np.float64],
     mbd_dgdcs: npt.NDArray[np.float64],
     mbd_dsdcs: npt.NDArray[np.float64],
 ):
@@ -269,7 +269,7 @@ def _calc_train(
     rb_ders = np.empty((itypes.size, radial_coeffs.shape[3], js.shape[1]))
     mb_vals = np.empty((itypes.size, alpha_moment_mapping.size))
     mb_ders = np.empty((itypes.size, alpha_moment_mapping.size, *rs.shape[1:]))
-    dedcs_l = np.empty((itypes.size, species_count, rfs, rbs))
+    dvdcs_l = np.empty((itypes.size, species_count, rfs, rbs))
     dgdcs_l = np.empty((itypes.size, species_count, rfs, rbs, *rs.shape[1:]))
 
     energies = species_coeffs[itypes]
@@ -286,7 +286,7 @@ def _calc_train(
             min_dist,
             max_dist,
         )
-        basis_values, basis_jac_rs, dedcs, dgdcs = calc_moments_train(
+        basis_values, basis_jac_rs, dvdcs, dgdcs = calc_moments_train(
             itypes[i],
             jtypes_i,
             r_abs,
@@ -308,7 +308,7 @@ def _calc_train(
         rb_ders[i] = rb_derivs
         mb_vals[i] = basis_values
         mb_ders[i] = basis_jac_rs
-        dedcs_l[i] = dedcs
+        dvdcs_l[i] = dvdcs
         dgdcs_l[i] = dgdcs
 
     for i in range(itypes.size):
@@ -333,7 +333,7 @@ def _calc_train(
         update_mbd_vatoms(i, mbd_vatoms, mb_vals[i])
         update_mbd_dbdris(i, js_i, mbd_dbdris, mb_ders[i])
         update_mbd_dbdeps(js_i, rs_i, mbd_dbdeps, mb_ders[i])
-        update_mbd_dedcs(itypes[i], mbd_dedcs, dedcs_l[i])
+        update_mbd_dvdcs(i, itypes[i], mbd_dvdcs, dvdcs_l[i])
         update_mbd_dgdcs(i, itypes[i], js_i, mbd_dgdcs, dgdcs_l[i])
         update_mbd_dsdcs(itypes[i], js_i, rs_i, mbd_dsdcs, dgdcs_l[i])
 

--- a/motep/potentials/mtp/numba/moment.py
+++ b/motep/potentials/mtp/numba/moment.py
@@ -43,17 +43,18 @@ def update_mbd_dbdeps(
                     )
 
 
-@nb.njit((nb.int32, nb.float64[:, :, :, :], nb.float64[:, :, :]))
-def update_mbd_dedcs(
+@nb.njit((nb.int32, nb.int32, nb.float64[:, :, :, :, :], nb.float64[:, :, :]))
+def update_mbd_dvdcs(
+    i: np.int32,
     itype: np.int32,
-    mbd_dedcs: npt.NDArray[np.float64],
-    tmp_dedcs: npt.NDArray[np.float64],
+    mbd_dvdcs: npt.NDArray[np.float64],
+    tmp_dvdcs: npt.NDArray[np.float64],
 ) -> None:
-    _, s1, s2, s3 = mbd_dedcs.shape
+    _, s1, s2, s3, _ = mbd_dvdcs.shape
     for i1 in range(s1):
         for i2 in range(s2):
             for i3 in range(s3):
-                mbd_dedcs[itype, i1, i2, i3] += tmp_dedcs[i1, i2, i3]
+                mbd_dvdcs[itype, i1, i2, i3, i] += tmp_dvdcs[i1, i2, i3]
 
 
 @nb.njit(
@@ -393,21 +394,21 @@ def _calc_moment_basic_with_jacobian_radial_coeffs(
 
 
 @nb.njit(nb.float64[:, :, :](nb.int32[:], nb.float64[:], nb.float64[:, :, :, :]))
-def _calc_dedcs(
+def _calc_dvdcs(
     alpha_moment_mapping: np.ndarray,
     moment_coeffs: np.ndarray,
     moment_jac_cs: np.ndarray,
-) -> None:
+) -> np.ndarray:
     spc, rfc, rbs = moment_jac_cs.shape[1:]
-    dedcs = np.zeros((spc, rfc, rbs))
+    dvdcs = np.zeros((spc, rfc, rbs))
     for i, j in enumerate(alpha_moment_mapping):
         for ispc in range(spc):
             for irfc in range(rfc):
                 for irbs in range(rbs):
-                    dedcs[ispc, irfc, irbs] += (
+                    dvdcs[ispc, irfc, irbs] += (
                         moment_jac_cs[j, ispc, irfc, irbs] * moment_coeffs[i]
                     )
-    return dedcs
+    return dvdcs
 
 
 @nb.njit(
@@ -422,7 +423,7 @@ def _calc_dedcs(
         nb.float64[:, :, :, :, :, :],
     ),
 )
-def _calc_dedcs_and_dgdcs(
+def _calc_dvdcs_and_dgdcs(
     alpha_index_basic_count: np.int32,
     alpha_index_times: np.ndarray,
     alpha_moment_mapping: np.ndarray,
@@ -431,7 +432,7 @@ def _calc_dedcs_and_dgdcs(
     moment_jac_rs: np.ndarray,
     moment_jac_cs: np.ndarray,
     moment_jac_rc: np.ndarray,
-) -> np.ndarray:
+) -> tuple[np.ndarray, np.ndarray]:
     """Calculate dV/dc and d(dV/dr)/dc.
 
     - dV/dc: Jacobian of site energy to radial basis coefficients
@@ -439,7 +440,7 @@ def _calc_dedcs_and_dgdcs(
 
     Returns
     -------
-    dedcs : np.ndarray
+    dvdcs : np.ndarray
         dV/dc.
     dgdcs : np.ndarray
         d(dV/dr)/dc.
@@ -467,14 +468,14 @@ def _calc_dedcs_and_dgdcs(
                 dgdmb[i1, j, ixyz0] += mult * dgdmb[i3, j, ixyz0] * moment_values[i2]
                 dgdmb[i2, j, ixyz0] += mult * dgdmb[i3, j, ixyz0] * moment_values[i1]
 
-    dedcs = np.zeros((spc, rfc, rbs))
+    dvdcs = np.zeros((spc, rfc, rbs))
     for iamc in range(alpha_index_basic_count):
         v1 = dedmb[iamc]
         for ispc in range(spc):
             for irfc in range(rfc):
                 for irbs in range(rbs):
                     v0 = moment_jac_cs[iamc, ispc, irfc, irbs]
-                    dedcs[ispc, irfc, irbs] += v0 * v1
+                    dvdcs[ispc, irfc, irbs] += v0 * v1
 
     dgdcs = np.zeros(moment_jac_rc.shape[1:])
     for iamc in range(alpha_index_basic_count):
@@ -496,7 +497,7 @@ def _calc_dedcs_and_dgdcs(
                             v1 = dgdmb[iamc, j, ixyz]
                             dgdcs[ispc, irfc, irbs, j, ixyz] += v0 * v1
 
-    return dedcs, dgdcs
+    return dvdcs, dgdcs
 
 
 @nb.njit(
@@ -560,7 +561,7 @@ def calc_moments_train(
 
     _contract_moments(alpha_index_times, moment_values, moment_jac_rs)
 
-    dedcs, dgdcs = _calc_dedcs_and_dgdcs(
+    dvdcs, dgdcs = _calc_dvdcs_and_dgdcs(
         alpha_index_basic.shape[0],
         alpha_index_times,
         alpha_moment_mapping,
@@ -574,7 +575,7 @@ def calc_moments_train(
     return (
         moment_values[alpha_moment_mapping],
         moment_jac_rs[alpha_moment_mapping],
-        dedcs,
+        dvdcs,
         dgdcs,
     )
 

--- a/motep/potentials/mtp/numpy/engine.py
+++ b/motep/potentials/mtp/numpy/engine.py
@@ -67,7 +67,7 @@ class NumpyMTPEngine(EngineBase):
             js_i = js[i, :]
             rs_i = rs[i, :, :]
             jtypes = itypes[js_i]
-            basis_values, basis_jac_rs, dedcs, dgdcs = self._calc_basis(
+            basis_values, basis_jac_rs, dvdcs, dgdcs = self._calc_basis(
                 i,
                 itype,
                 js_i,
@@ -92,7 +92,7 @@ class NumpyMTPEngine(EngineBase):
                 self.mbd.dbdris[:, j] += basis_jac_rs[:, k]
             self.mbd.dbdeps += rs_i.T @ basis_jac_rs
 
-            self.mbd.dedcs[itype] += dedcs
+            self.mbd.dvdcs[itype, ..., i] = dvdcs
 
             for k, j in enumerate(js_i):
                 self.mbd.dgdcs[itype, :, :, :, i] -= dgdcs[:, :, :, k]

--- a/motep/potentials/mtp/numpy/moment.py
+++ b/motep/potentials/mtp/numpy/moment.py
@@ -21,7 +21,12 @@ class MomentBasis:
         r_ijs: npt.NDArray[np.float64],  # (neighbors, 3)
         r_abs: npt.NDArray[np.float64],  # (neighbors)
         rb: ChebyshevArrayRadialBasis,
-    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    ) -> tuple[
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+    ]:
         r"""Calculate basis functions and their derivatives.
 
         Parameters
@@ -114,7 +119,7 @@ class MomentBasis:
 
         moment_coeffs = self.mtp_data.moment_coeffs
 
-        dedcs, dgdcs = calc_dedcs_and_dgdcs(
+        dvdcs, dgdcs = _calc_dvdcs_and_dgdcs(
             self.mtp_data.alpha_index_basic_count,
             alpha_index_times,
             alpha_moment_mapping,
@@ -128,7 +133,7 @@ class MomentBasis:
         return (
             moment_values[alpha_moment_mapping],
             moment_jac_rs[alpha_moment_mapping],
-            dedcs,
+            dvdcs,
             dgdcs,
         )
 
@@ -157,7 +162,7 @@ def _contract_moments(
         )
 
 
-def calc_dedcs_and_dgdcs(
+def _calc_dvdcs_and_dgdcs(
     alpha_index_basic_count: np.int32,
     alpha_index_times: np.ndarray,
     alpha_moment_mapping: np.ndarray,
@@ -174,7 +179,7 @@ def calc_dedcs_and_dgdcs(
 
     Returns
     -------
-    dedcs : np.ndarray
+    dvdcs : np.ndarray
         dV/dc.
     dgdcs : np.ndarray
         d(dV/dr)/dc.
@@ -196,9 +201,9 @@ def calc_dedcs_and_dgdcs(
         i1, i2, mult, i3 = ait
         dgdmb[i1] += mult * dgdmb[i3] * moment_values[i2]
         dgdmb[i2] += mult * dgdmb[i3] * moment_values[i1]
-    dedcs = (moment_jac_cs[:aibc].T @ dedmb[:aibc]).T
+    dvdcs = (moment_jac_cs[:aibc].T @ dedmb[:aibc]).T
     dgdcs = (moment_jac_rc[:aibc].T @ dedmb[:aibc]).T
     dgdcs += (
         moment_jac_cs[:aibc, ..., None, None] * dgdmb[:aibc, None, None, None]
     ).sum(axis=0)
-    return dedcs, dgdcs
+    return dvdcs, dgdcs

--- a/tests/grade/test_cli_grade.py
+++ b/tests/grade/test_cli_grade.py
@@ -11,8 +11,8 @@ from motep.grade.grader import load_setting_grade
 def test_cli_grade(data_path: Path, tmp_path: Path) -> None:
     """Test `motep grade`."""
     with chdir(tmp_path):
-        shutil.copy2(data_path / "original/molecules/291/training.cfg", ".")
-        shutil.copy2(data_path / "fitting/molecules/291/02/pot.mtp", "final.mtp")
+        shutil.copy2(data_path / "original/crystals/cubic/training.cfg", ".")
+        shutil.copy2(data_path / "fitting/crystals/cubic/02/pot.mtp", "final.mtp")
         shutil.copy2("training.cfg", "initial.cfg")
         Path("motep.grade.toml").touch()  # empty
         args = ["motep", "grade", "motep.grade.toml"]

--- a/tests/grade/test_grader.py
+++ b/tests/grade/test_grader.py
@@ -12,6 +12,7 @@ from motep.io.mlip.mtp import read_mtp
 _optimized = [
     ["moment_coeffs"],
     ["moment_coeffs", "species_coeffs"],
+    ["moment_coeffs", "species_coeffs", "radial_coeffs"],
 ]
 
 

--- a/tests/grade/test_grader.py
+++ b/tests/grade/test_grader.py
@@ -9,14 +9,20 @@ from motep.grade.grader import GradeMode, Grader
 from motep.io.mlip.cfg import read_cfg
 from motep.io.mlip.mtp import read_mtp
 
+_optimized = [
+    ["moment_coeffs"],
+    ["moment_coeffs", "species_coeffs"],
+]
+
 
 @pytest.mark.parametrize("mode", list(GradeMode))
-def test_grader(mode: GradeMode, data_path: Path) -> None:
+@pytest.mark.parametrize("optimized", _optimized)
+def test_grader(optimized: list[str], mode: GradeMode, data_path: Path) -> None:
     """Test if `Grader` works."""
     path = data_path / "fitting/crystals/multi/10"
     images_training = read_cfg(path / "out.cfg", index=":")
     mtp_data = read_mtp(path / "pot.mtp")
-    mtp_data.optimized = ["moment_coeffs"]
+    mtp_data.optimized = optimized
 
     grades_ref = [atoms.calc.results["MV_grade"] for atoms in images_training]
 

--- a/tests/grade/test_grader.py
+++ b/tests/grade/test_grader.py
@@ -16,6 +16,7 @@ def test_grader(mode: GradeMode, data_path: Path) -> None:
     path = data_path / "fitting/crystals/multi/10"
     images_training = read_cfg(path / "out.cfg", index=":")
     mtp_data = read_mtp(path / "pot.mtp")
+    mtp_data.optimized = ["moment_coeffs"]
 
     grades_ref = [atoms.calc.results["MV_grade"] for atoms in images_training]
 


### PR DESCRIPTION
closes #91 

With this PR, the `Grader` can consider `species_coeffs` and `radial_coeffs`, in addition to presently implemented `moment_coeffs`, to be consistent with those in mlip-2/3. We can control which to consider via `mtp_data.optimized`, like the `Trainer` class.

This requires to keep the derivatives of *local energies* with request to `radial_coeffs` and thus needs to modify each `engine` including `numba` and `cext`. I therefore would like to request @axefor your notice and review.
Particularly, this change requires (1) running `Grader` with the `train` mode, making the speed substantially slower and (2) more memory during training. Both could be moderated by having the `grade` mode to store only necessary variables for grading, which has not yet implemented though.

Since this will also require further rebasing for #89, it would probably makes life simpler if we can first decide to push https://github.com/yuzie007/motep/pull/4 to your branch in #89.

