### PR TITLE
Add the MaxVol algorithm implemented in MLIP-2/3

### DIFF
--- a/motep/grade/maxvol.py
+++ b/motep/grade/maxvol.py
@@ -199,6 +199,66 @@ def _maxvol(
     )
 
 
+def _mlip(
+    matrix: np.ndarray,
+    *,
+    maxiter: int = 100_000,
+) -> MaxVolResult:
+    """Algorithm implemented in MLIP-2/3.
+
+    This algorithm incrementally updates the maximum-volume submatrix starting
+    from the scaled identity matrix.
+    The parameters are hard-coded to mimic the default behavior of MLIP-2/3.
+    Note however that the update can be incomplete, and therefore the canonical
+    MaxVol algorithm is recommended except for cross-checking purposes.
+
+    Returns
+    -------
+    MaxVolResult
+
+    """
+    _validate_matrix(matrix)
+    success = True
+
+    threshold = 1e-3
+    nrows, ncols = matrix.shape
+    selected = np.full(ncols, -1, dtype=int)
+    order = np.arange(nrows, dtype=int)
+
+    init_threshold = 1e-6
+    submatrix = init_threshold * np.eye(ncols)
+    inv_submatrix = (1.0 / init_threshold) * np.eye(ncols)
+
+    c = matrix @ inv_submatrix
+    for nit in range(maxiter):
+        i, j = np.divmod(np.argmax(np.abs(c)), ncols)
+        cmax = np.abs(c[i, j])
+        logger.info("maxvol %d: %s (%s, %s)", nit, cmax, i, j)
+        if cmax - 1.0 < threshold:
+            break
+        if order[i] in selected:
+            break
+        k = order[i]  # index for rows of the original matrix
+        selected[j] = k
+        _update_inv_submatrix(inv_submatrix, c[i], j)
+        _update_c(c, i, j)
+        c[[i, j]] = c[[j, i]]
+        order[[i, j]] = order[[j, i]]
+        submatrix[j] = matrix[k]
+
+    if np.any(selected == -1):
+        logger.warning("Some parameters have not been selected.")
+        logger.warning(np.where(selected == -1)[0])
+        success = False
+
+    return MaxVolResult(
+        indices=selected[selected != -1],
+        submatrix=submatrix,
+        success=success,
+        nit=nit,
+    )
+
+
 def _calc_c(matrix: np.ndarray, selected: np.ndarray) -> np.ndarray:
     """Calculate c explicitly based on c @ matrix = matrix[selected].
 
@@ -221,11 +281,27 @@ def _update_c(c: np.ndarray, i: np.int_, j: np.int_) -> None:
     c -= np.outer(col, row) / c[i, j]
 
 
+def _update_inv_submatrix(
+    inv_submatrix: np.ndarray,
+    tmp: np.ndarray,
+    j: np.int_,
+) -> None:
+    """Update inv(sub(A)) based on the rank-1 update.
+
+    https://en.wikipedia.org/wiki/Sherman%E2%80%93Morrison_formula
+    """
+    row = tmp.copy()
+    row[j] -= 1.0
+    col = inv_submatrix[:, j].copy()
+    inv_submatrix -= np.outer(col, row) / tmp[j]
+
+
 class FindMethod(StrEnum):
     """Finding method for the indices for he MaxVol calculation."""
 
     EXHAUST = "exhaust"
     MAXVOL = "maxvol"
+    MLIP = "mlip"
 
 
 @dataclass
@@ -294,4 +370,6 @@ class MaxVol:
                 threshold=self.threshold,
                 maxiter=self.maxiter,
             )
+        if self.algorithm == FindMethod.MLIP:
+            return _mlip(matrix)
         raise ValueError(self.algorithm)

--- a/tests/grade/test_grader.py
+++ b/tests/grade/test_grader.py
@@ -25,12 +25,26 @@ def test_grader(optimized: list[str], mode: GradeMode, data_path: Path) -> None:
     mtp_data = read_mtp(path / "pot.mtp")
     mtp_data.optimized = optimized
 
+    grader = Grader(mtp_data, mode=mode)
+    grader.update(images_training)
+    images_out = grader.grade(images_training)
+
+    assert all("MV_grade" in atoms.calc.results for atoms in images_out)
+
+
+def test_comparision_with_mlip(data_path: Path) -> None:
+    """Test if `Grader` gives the extrapolation grades consistent with MLIP."""
+    path = data_path / "fitting/crystals/multi/10"
+    images_training = read_cfg(path / "out.cfg", index=":")
+    mtp_data = read_mtp(path / "pot.mtp")
+    mtp_data.optimized = ["moment_coeffs", "species_coeffs", "radial_coeffs"]
+
     grades_ref = [atoms.calc.results["MV_grade"] for atoms in images_training]
 
-    grader = Grader(mtp_data, mode=mode)
+    grader = Grader(mtp_data, mode="neighborhood", maxvol_setting={"algorithm": "mlip"})
     grader.update(images_training)
     images_out = grader.grade(images_training)
 
     grades = [atoms.calc.results["MV_grade"] for atoms in images_out]
 
-    # np.testing.assert_allclose(grades, grades_ref)  # TODO
+    np.testing.assert_allclose(grades, grades_ref, rtol=1e-6, atol=1e-6)


### PR DESCRIPTION
This PR is on top of #93 and to be considered after that.

This PR adds the MaxVol algorithm implemented in MLIP-2/3.

The algorithm incrementally updates the submatrix starting from the scaled identity matrix. The update in this approach can be incomplete, and therefore I would recommend people using the canonical MaxVol algorithm implemented already. However, for cross-checking purposes in comparison with MLIP-2/3, this approach may be helpful.