### PR TITLE
Build wheels for Intel MacOS

### DIFF
--- a/.github/actions/download-dist-artifacts/action.yml
+++ b/.github/actions/download-dist-artifacts/action.yml
@@ -13,8 +13,13 @@ runs:
       with:
         name: motep-ubuntu-latest
         path: dist
-    - name: Download macOS wheels
+    - name: Download ARM macOS wheels
       uses: actions/download-artifact@v8
       with:
         name: motep-macos-latest
+        path: dist
+    - name: Download Intel macOS wheels
+      uses: actions/download-artifact@v8
+      with:
+        name: motep-macos-15-intel
         path: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Install runtime NumPy and test deps
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "numpy${{ matrix.numpy }}" ase scipy numba jax pytest
+          python -m pip install "numpy${{ matrix.numpy }}" --only-binary=numba ase scipy numba jax pytest
       - name: Install built wheel
         run: python -m pip install --no-deps dist/*cp311*.whl
       - name: Run pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
+          - macos-15-intel
     steps:
       - uses: actions/checkout@v6
         with:
@@ -72,6 +73,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
+          - macos-15-intel
         numpy:
           - "==1.23.5"
           - ">=2,<3"


### PR DESCRIPTION
This PR builds wheels for Intel MacOS.

There are still a certain number of users of Intel MacOS. For them, it would be convenient if we have pre-compiled wheels.

Further, this may be helpful when we later upload `motep` to `conda-forge`; it still considers Intel MacOS primarily, and the package for ARM MacOS is often made by cross-compiling.

The change in this PR is in principle just adding the GitHub runner `macos-15-intel` (cf. https://github.com/actions/runner-images?tab=readme-ov-file#available-images). There was however one issue related to `numba` during testing the wheels. [Since 0.63.0, `numba` deprecates support for Intel MacOS](https://numba.readthedocs.io/en/stable/release/0.63.0-notes.html#version-0-63-0-8-december-2025), and the latest version does not offer wheels for Intel MacOS. It therefore requires compiling from source, [which however fails on GitHub Actions](https://github.com/yuzie007/motep/actions/runs/24459605663/job/71470269485#step:5:172). To circumvent the issue, I modified `build.yml` to install the version that offers wheels. For Linux and ARM MacOS, it changes nothing, while Intel MacOS installs a bit older versions for testing. This means we cannot use a very latest functionalities of Numba to pass the tests, but I think it would not be a big problem.