### PR TITLE
Fix `Level2MTPOptimizer` when optimizing `species_coeffs` for configurations some of which do not have `forces` and/or `stress`

### DIFF
--- a/motep/optimizers/lls.py
+++ b/motep/optimizers/lls.py
@@ -61,14 +61,17 @@ class LLSOptimizerBase(ParallelOptimizerBase):
         # `species_coeffs` do not affect forces and stresses,
         # and therefore the corresponding sub-mattrices should be zero-filled.
         if "forces" in self.minimized:
-            nforces = sum(atoms.calc.targets["forces"].size for atoms in images)
+            idcs_frc = self.loss.loss_forces.idcs_frc
+            nforces = sum(images[i].calc.targets["forces"].size for i in idcs_frc)
             shape = (nforces, len(species))
             tmp.append(np.zeros(shape))
         if "stress" in self.minimized:
-            shape = (9 * len(images), len(species))
+            idcs_str = self.loss.loss_stress.idcs_str
+            shape = (9 * idcs_str.size, len(species))
             tmp.append(np.zeros(shape))
         if "mgrad" in self.minimized:
-            nmmg = sum(atoms.calc.targets["mgrad"].size for atoms in images)
+            idcs_mgd = self.loss.loss_mgrad.idcs_mgd
+            nmmg = sum(images[i].calc.targets["mgrad"].size for i in idcs_mgd)
             shape = (nmmg, len(species))
             tmp.append(np.zeros(shape))
         return np.vstack(tmp)

--- a/tests/optimizers/test_level2mtp.py
+++ b/tests/optimizers/test_level2mtp.py
@@ -50,7 +50,6 @@ def make_crystals(
 
 def test_without_forces(data_path: pathlib.Path) -> None:
     """Test if `Level2MTPOptimizer` works for the training data without forces."""
-    engine = "numpy"
     molecule = 762
     level = 2
     images, mtp_data = make_molecules(molecule, level, data_path)
@@ -71,7 +70,6 @@ def test_without_forces(data_path: pathlib.Path) -> None:
         mtp_data=mtp_data,
         setting=setting,
         comm=world,
-        engine=engine,
     )
 
     optimized = ["radial_coeffs"]

--- a/tests/optimizers/test_level2mtp.py
+++ b/tests/optimizers/test_level2mtp.py
@@ -17,6 +17,10 @@ from motep.potentials.mtp.data import MTPData
 
 logger = logging.getLogger(__name__)
 
+_optimized = [["radial_coeffs"], ["radial_coeffs", "species_coeffs"]]
+
+_minimized = [["energy"], ["energy", "forces"], ["energy", "forces", "stress"]]
+
 
 def make_molecules(
     molecule: int,
@@ -48,20 +52,24 @@ def make_crystals(
     return images, mtp_data
 
 
-def test_without_forces(data_path: pathlib.Path) -> None:
+@pytest.mark.parametrize("minimized", _minimized)
+@pytest.mark.parametrize("optimized", _optimized)
+def test_without_forces_and_stress(
+    data_path: pathlib.Path,
+    optimized: list[str],
+    minimized: list[str],
+) -> None:
     """Test if `Level2MTPOptimizer` works for the training data without forces."""
     molecule = 762
     level = 2
     images, mtp_data = make_molecules(molecule, level, data_path)
 
     for atoms in images:
-        del atoms.calc.results["forces"]
+        for key in ["forces", "stress"]:
+            if key in atoms.calc.results:
+                del atoms.calc.results[key]
 
-    setting = LossSetting(
-        energy_weight=1.0,
-        forces_weight=0.01,
-        stress_weight=0.0,
-    )
+    setting = LossSetting()
 
     rng = np.random.default_rng(42)
 
@@ -72,9 +80,6 @@ def test_without_forces(data_path: pathlib.Path) -> None:
         comm=world,
     )
 
-    optimized = ["radial_coeffs"]
-
-    minimized = ["energy", "forces"]
     optimizer = Level2MTPOptimizer(loss, optimized=optimized, minimized=minimized)
 
     mtp_data.optimized = optimized
@@ -182,13 +187,7 @@ def test_molecules(
     assert f_e00 < f_ref
 
 
-@pytest.mark.parametrize(
-    "optimized",
-    [
-        ["radial_coeffs"],
-        ["radial_coeffs", "species_coeffs"],
-    ],
-)
+@pytest.mark.parametrize("optimized", _optimized)
 @pytest.mark.parametrize(
     (
         "energy_per_atom",


### PR DESCRIPTION
The present `Level2MTPOptimizer` raises an error when we optimize `species_coeffs` (together with `radial_coeffs`) for configurations some of which does not have `forces` and/or `stress` (e.g. molecular systems) as
```
Traceback (most recent call last):
  File "/Users/ikeda/miniforge3/envs/myenv/bin/motep", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/ikeda/codes/motep/motep/cli.py", line 40, in main
    commands[args.command].run(args)
  File "/Users/ikeda/codes/motep/motep/train/cli.py", line 19, in run
    train_from_setting(args.setting, comm=world)
  File "/Users/ikeda/codes/motep/motep/train/trainer.py", line 171, in train_from_setting
    trainer.train(images)
  File "/Users/ikeda/codes/motep/motep/train/trainer.py", line 122, in train
    optimizer.optimize(**step.get("kwargs", {}))
  File "/Users/ikeda/codes/motep/motep/optimizers/base.py", line 152, in optimize
    result_x = self._optimize(**kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ikeda/codes/motep/motep/optimizers/level2mtp.py", line 50, in _optimize
    matrix = self._calc_matrix()
             ^^^^^^^^^^^^^^^^^^^
  File "/Users/ikeda/codes/motep/motep/optimizers/level2mtp.py", line 96, in _calc_matrix
    return np.hstack(tmp)
           ^^^^^^^^^^^^^^
  File "/Users/ikeda/miniforge3/envs/myenv/lib/python3.11/site-packages/numpy/core/shape_base.py", line 359, in hstack
    return _nx.concatenate(arrs, 1, dtype=dtype, casting=casting)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: all the input array dimensions except for the concatenation axis must match exactly, but along dimension 0, the array at index 0 has size 97364 and the array at index 1 has size 106454
```
This happens because the present `_calc_matrix_species_coeffs` do not check if each ASE Atoms object has `forces` or `stress`.

The present PR fixes the issue above. The test `test_without_forces_and_stress` is extended to check more combinations of `optimized` (now including `species_coeffs`) and `minimized` (now including `stress`).