### PR TITLE
Fix to use `dvdcs` for `mmtp`

### DIFF
--- a/motep/potentials/mmtp/numba/engine.py
+++ b/motep/potentials/mmtp/numba/engine.py
@@ -18,7 +18,7 @@ from motep.potentials.mtp.numba.moment import (
     store_radial_basis,
     update_mbd_dbdeps,
     update_mbd_dbdris,
-    update_mbd_dedcs,
+    update_mbd_dvdcs,
     update_mbd_dgdcs,
     update_mbd_dsdcs,
     update_mbd_vatoms,
@@ -131,7 +131,7 @@ class NumbaMagMTPEngine(MagEngineBase):
             self.mbd.vatoms,
             self.mbd.dbdris,
             self.mbd.dbdeps,
-            self.mbd.dedcs,
+            self.mbd.dvdcs,
             self.mbd.dgdcs,
             self.mbd.dsdcs,
         )
@@ -211,7 +211,7 @@ class NumbaMagMTPEngine(MagEngineBase):
             self.mbd.dbdris,
             self.mbd.dbdmis,
             self.mbd.dbdeps,
-            self.mbd.dedcs,
+            self.mbd.dvdcs,
             self.mbd.dgdcs,
             self.mbd.dgmdcs,
             self.mbd.dsdcs,
@@ -386,7 +386,7 @@ def _calc_mag_run(
         nb.float64[:, :],
         nb.float64[:, :, :],
         nb.float64[:, :, :],
-        nb.float64[:, :, :, :],
+        nb.float64[:, :, :, :, :],  # mbd_dvdcs
         nb.float64[:, :, :, :, :, :],
         nb.float64[:, :, :, :, :, :],
     ),
@@ -419,7 +419,7 @@ def _calc_mag_train(
     mbd_vatoms: npt.NDArray[np.float64],
     mbd_dbdris: npt.NDArray[np.float64],
     mbd_dbdeps: npt.NDArray[np.float64],
-    mbd_dedcs: npt.NDArray[np.float64],
+    mbd_dvdcs: npt.NDArray[np.float64],
     mbd_dgdcs: npt.NDArray[np.float64],
     mbd_dsdcs: npt.NDArray[np.float64],
 ):
@@ -429,8 +429,8 @@ def _calc_mag_train(
     drb_drs = np.empty((nis, radial_coeffs.shape[3], njs))
     mb_vals = np.empty((nis, alpha_moment_mapping.size))
     mb_jac_rs = np.empty((nis, alpha_moment_mapping.size, njs, 3))
-    dedcs = np.empty((nis, species_count, rfs, rbs))
-    dgdcs = np.empty((nis, species_count, rfs, rbs, njs, 3))
+    dvdcs_l = np.empty((nis, species_count, rfs, rbs))
+    dgdcs_l = np.empty((nis, species_count, rfs, rbs, njs, 3))
 
     energies = species_coeffs[itypes]
     for i in nb.prange(itypes.size):
@@ -452,7 +452,7 @@ def _calc_mag_train(
             min_mag,
             max_mag,
         )
-        (mb_vals_i, mb_jac_rs_i, dedcs_i, dgdcs_i) = calc_moments_train(
+        mb_vals_i, mb_jac_rs_i, dvdcs, dgdcs = calc_moments_train(
             itypes[i],
             jtypes_i,
             r_abs,
@@ -474,8 +474,8 @@ def _calc_mag_train(
         drb_drs[i] = drb_drs_i
         mb_vals[i] = mb_vals_i
         mb_jac_rs[i] = mb_jac_rs_i
-        dedcs[i] = dedcs_i
-        dgdcs[i] = dgdcs_i
+        dvdcs_l[i] = dvdcs
+        dgdcs_l[i] = dgdcs
 
     for i in range(itypes.size):
         js_i = js[i, :]
@@ -499,9 +499,9 @@ def _calc_mag_train(
         update_mbd_vatoms(i, mbd_vatoms, mb_vals[i])
         update_mbd_dbdris(i, js_i, mbd_dbdris, mb_jac_rs[i])
         update_mbd_dbdeps(js_i, rs_i, mbd_dbdeps, mb_jac_rs[i])
-        update_mbd_dedcs(itypes[i], mbd_dedcs, dedcs[i])
-        update_mbd_dgdcs(i, itypes[i], js_i, mbd_dgdcs, dgdcs[i])
-        update_mbd_dsdcs(itypes[i], js_i, rs_i, mbd_dsdcs, dgdcs[i])
+        update_mbd_dvdcs(i, itypes[i], mbd_dvdcs, dvdcs_l[i])
+        update_mbd_dgdcs(i, itypes[i], js_i, mbd_dgdcs, dgdcs_l[i])
+        update_mbd_dsdcs(itypes[i], js_i, rs_i, mbd_dsdcs, dgdcs_l[i])
 
     return energies
 
@@ -535,7 +535,7 @@ def _calc_mag_train(
         nb.float64[:, :, :],
         nb.float64[:, :],
         nb.float64[:, :, :],
-        nb.float64[:, :, :, :],
+        nb.float64[:, :, :, :, :],  # mbd_dvdcs
         nb.float64[:, :, :, :, :, :],
         nb.float64[:, :, :, :, :],
         nb.float64[:, :, :, :, :, :],
@@ -571,7 +571,7 @@ def _calc_mag_train_mgrad(
     mbd_dbdris: npt.NDArray[np.float64],
     mbd_dbdmis: npt.NDArray[np.float64],
     mbd_dbdeps: npt.NDArray[np.float64],
-    mbd_dedcs: npt.NDArray[np.float64],
+    mbd_dvdcs: npt.NDArray[np.float64],
     mbd_dgdcs: npt.NDArray[np.float64],
     mbd_dgmdcs: npt.NDArray[np.float64],
     mbd_dsdcs: npt.NDArray[np.float64],
@@ -586,8 +586,8 @@ def _calc_mag_train_mgrad(
     mb_jac_rs = np.empty((nis, alpha_moment_mapping.size, njs, 3))
     mb_jac_mis = np.empty((nis, alpha_moment_mapping.size, njs))
     mb_jac_mjs = np.empty((nis, alpha_moment_mapping.size, njs))
-    dedcs = np.empty((nis, species_count, rfs, rbs))
-    dgdcs = np.empty((nis, species_count, rfs, rbs, njs, 3))
+    dvdcs_l = np.empty((nis, species_count, rfs, rbs))
+    dgdcs_l = np.empty((nis, species_count, rfs, rbs, njs, 3))
     dgmidcs = np.empty((nis, species_count, rfs, rbs, njs))
     dgmjdcs = np.empty((nis, species_count, rfs, rbs, njs))
 
@@ -616,8 +616,8 @@ def _calc_mag_train_mgrad(
             mb_jac_rs_i,
             mb_jac_mis_i,
             mb_jac_mjs_i,
-            dedcs_i,
-            dgdcs_i,
+            dvdcs,
+            dgdcs,
             dgmidcs_i,
             dgmjdcs_i,
         ) = calc_mag_moments_train(
@@ -648,8 +648,8 @@ def _calc_mag_train_mgrad(
         mb_jac_rs[i] = mb_jac_rs_i
         mb_jac_mis[i] = mb_jac_mis_i
         mb_jac_mjs[i] = mb_jac_mjs_i
-        dedcs[i] = dedcs_i
-        dgdcs[i] = dgdcs_i
+        dvdcs_l[i] = dvdcs
+        dgdcs_l[i] = dgdcs
         dgmidcs[i] = dgmidcs_i
         dgmjdcs[i] = dgmjdcs_i
 
@@ -679,9 +679,9 @@ def _calc_mag_train_mgrad(
         update_mbd_dbdris(i, js_i, mbd_dbdris, mb_jac_rs[i])
         update_mbd_dbdmis(i, js_i, mbd_dbdmis, mb_jac_mis[i], mb_jac_mjs[i])
         update_mbd_dbdeps(js_i, rs_i, mbd_dbdeps, mb_jac_rs[i])
-        update_mbd_dedcs(itypes[i], mbd_dedcs, dedcs[i])
-        update_mbd_dgdcs(i, itypes[i], js_i, mbd_dgdcs, dgdcs[i])
+        update_mbd_dvdcs(i, itypes[i], mbd_dvdcs, dvdcs_l[i])
+        update_mbd_dgdcs(i, itypes[i], js_i, mbd_dgdcs, dgdcs_l[i])
         update_mbd_dgmdcs(i, itypes[i], js_i, mbd_dgmdcs, dgmidcs[i], dgmjdcs[i])
-        update_mbd_dsdcs(itypes[i], js_i, rs_i, mbd_dsdcs, dgdcs[i])
+        update_mbd_dsdcs(itypes[i], js_i, rs_i, mbd_dsdcs, dgdcs_l[i])
 
     return energies

--- a/motep/potentials/mmtp/numba/moment.py
+++ b/motep/potentials/mmtp/numba/moment.py
@@ -278,7 +278,7 @@ def _calc_mag_moment_basic_with_jacobian_radial_coeffs(
         nb.float64[:, :, :, :, :],
     ),
 )
-def _calc_mag_dedcs_and_dgdcs(
+def _calc_mag_dvdcs_and_dgdcs(
     alpha_index_basic_count: np.int32,
     alpha_index_times: np.ndarray,
     alpha_moment_mapping: np.ndarray,
@@ -299,7 +299,7 @@ def _calc_mag_dedcs_and_dgdcs(
 
     Returns
     -------
-    dedcs : np.ndarray
+    dvdcs : np.ndarray
         dV/dc.
     dgdcs : np.ndarray
         d(dV/dr)/dc.
@@ -341,14 +341,14 @@ def _calc_mag_dedcs_and_dgdcs(
                 dgdmb[i1, j, ixyz0] += mult * dgdmb[i3, j, ixyz0] * moment_values[i2]
                 dgdmb[i2, j, ixyz0] += mult * dgdmb[i3, j, ixyz0] * moment_values[i1]
 
-    dedcs = np.zeros((spc, rfc, rbs))
+    dvdcs = np.zeros((spc, rfc, rbs))
     for iamc in range(alpha_index_basic_count):
         v1 = dedmb[iamc]
         for ispc in range(spc):
             for irfc in range(rfc):
                 for irbs in range(rbs):
                     v0 = moment_jac_cs[iamc, ispc, irfc, irbs]
-                    dedcs[ispc, irfc, irbs] += v0 * v1
+                    dvdcs[ispc, irfc, irbs] += v0 * v1
 
     dgdcs = np.zeros(moment_jac_rc.shape[1:])
     dgmidcs = np.zeros(moment_jac_mic.shape[1:])
@@ -372,7 +372,7 @@ def _calc_mag_dedcs_and_dgdcs(
                             dgdcs[ispc, irfc, irbs, j, ixyz] += v2 * v1
                             dgdcs[ispc, irfc, irbs, j, ixyz] += v3 * v4
 
-    return dedcs, dgdcs, dgmidcs, dgmjdcs
+    return dvdcs, dgdcs, dgmidcs, dgmjdcs
 
 
 @nb.njit
@@ -641,7 +641,7 @@ def calc_mag_moments_train(
         moment_jac_mjs,
     )
 
-    dedcs, dgdcs, dgmidcs, dgmjdcs = _calc_mag_dedcs_and_dgdcs(
+    dvdcs, dgdcs, dgmidcs, dgmjdcs = _calc_mag_dvdcs_and_dgdcs(
         alpha_index_basic.shape[0],
         alpha_index_times,
         alpha_moment_mapping,
@@ -661,7 +661,7 @@ def calc_mag_moments_train(
         moment_jac_rs[alpha_moment_mapping],
         moment_jac_mis[alpha_moment_mapping],
         moment_jac_mjs[alpha_moment_mapping],
-        dedcs,
+        dvdcs,
         dgdcs,
         dgmidcs,
         dgmjdcs,


### PR DESCRIPTION
This PR fixes the conflict between #97 and #91 to solve the errors in `test_mmtp.py` after merging. (https://github.com/imw-md/motep/actions/runs/24507707474/job/71630401675)

#91 introduces `dvdcs` to store the Jacobian of site energies wrt the radial coeffs. To make the changes noticable I introduced `dvdcs` to replace `dedcs` (Jacobian, but for the total energies).