### PR TITLE
Log INFO for CLI

### DIFF
--- a/motep/cli.py
+++ b/motep/cli.py
@@ -9,7 +9,7 @@ import motep.grade.cli
 import motep.train.cli
 import motep.upconvert.cli
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("motep")
 logger.setLevel(logging.DEBUG)
 stdout_handler = logging.StreamHandler(sys.stdout)
 stdout_handler.setLevel(logging.INFO)


### PR DESCRIPTION
This PR suggests printing the log messages at the INFO level (and above) when the code executed from the CLI.

For Python API, where `motep` is executed as a library, it is reasonable *not* to print many by default. On the other hand, for CLI, we can redirect stdout to a file for a later analysis. I therefore think it is reasonable to print the INFO level messages, somehow like mlip-2/3.

Regarding the technical approach, I am not very much familiar with a good convention for logging. While I take the most rough way to modify `basicConfig`, we can also do e.g. `logger = logging.getLogger("motep")`, to limit the impact within the `motep` code. I am however not sure if this is necessary for CLI. @axefor Do you have any ideas?