### PR TITLE
Revert to inherit normal `OptimizerBase` for non-SciPy optimizers

### DIFF
--- a/motep/optimizers/__init__.py
+++ b/motep/optimizers/__init__.py
@@ -1,6 +1,6 @@
 """Module for `Optimizer` classes."""
 
-from motep.optimizers.base import ParallelOptimizerBase
+from motep.optimizers.base import OptimizerBase
 from motep.optimizers.ga import GeneticAlgorithmOptimizer
 from motep.optimizers.ideal import NoInteractionOptimizer
 from motep.optimizers.level2mtp import Level2MTPOptimizer
@@ -13,12 +13,12 @@ from motep.optimizers.scipy import (
 )
 
 
-def make_optimizer(optimizer: str) -> type[ParallelOptimizerBase]:
+def make_optimizer(optimizer: str) -> type[OptimizerBase]:
     """Make an `Optimizer` class.
 
     Returns
     -------
-    type[ParallelOptimizerBase]
+    type[OptimizerBase]
 
     """
     return {

--- a/motep/optimizers/base.py
+++ b/motep/optimizers/base.py
@@ -32,8 +32,6 @@ class OptimizerBase(ABC):
     def __init__(
         self,
         loss: LossFunctionBase,
-        *,
-        comm: DummyMPIComm = world,
         **kwargs: dict[str, Any],
     ) -> None:
         """Initialize the `Optimizer` class.
@@ -42,8 +40,6 @@ class OptimizerBase(ABC):
         ----------
         loss : :class:`motep.loss.LossFunction`
             :class:`motep.loss.LossFunction` object.
-        comm : MPI.Comm
-            MPI.Comm object.
         **kwargs : dict[str, Any]
             Options passed to the `Optimizer` class.
 
@@ -53,7 +49,6 @@ class OptimizerBase(ABC):
 
         """
         self.loss = loss
-        self.comm = comm
 
         if "optimized" not in kwargs:
             self.optimized = self.optimized_default

--- a/motep/optimizers/ga.py
+++ b/motep/optimizers/ga.py
@@ -6,10 +6,9 @@ from collections.abc import Callable
 from typing import Any
 
 import numpy as np
-import numpy.typing as npt
 from scipy.optimize import minimize
 
-from motep.optimizers.base import ParallelOptimizerBase
+from motep.optimizers.base import OptimizerBase
 
 logger = logging.getLogger(__name__)
 
@@ -375,7 +374,7 @@ def elite_callback(gen: int, elite: float) -> None:
     logger.info("Generation %s: Top Elite - %s", gen, elite)
 
 
-class GeneticAlgorithmOptimizer(ParallelOptimizerBase):
+class GeneticAlgorithmOptimizer(OptimizerBase):
     """Optimizer based on genetic algorithm (GA).
 
     This function is a wrapper for using the GA to optimize a target function.
@@ -387,18 +386,12 @@ class GeneticAlgorithmOptimizer(ParallelOptimizerBase):
 
     """
 
-    def _optimize(self, **kwargs: dict[str, Any]) -> npt.NDArray[np.float64]:
-        """Optimize parameters.
-
-        Returns
-        -------
-        npt.NDArray[np.float64]
-
-        """
+    def optimize(self, **kwargs: dict[str, Any]) -> None:
+        """Optimize parameters."""
         parameters = self.loss.mtp_data.parameters
         bounds = _limit_bounds(self.loss.mtp_data.get_bounds())
         ga = GeneticAlgorithm(
-            self.rank0_loss,
+            self.loss,
             parameters,
             lower_bound=bounds[:, 0],
             upper_bound=bounds[:, 1],
@@ -409,8 +402,8 @@ class GeneticAlgorithmOptimizer(ParallelOptimizerBase):
             superhuman=True,
         )
         ga.initialize_population()
-        return ga.evolve_with_mix(
-            self.rank0_loss,
+        self.loss.mtp_data.parameters = ga.evolve_with_mix(
+            self.loss,
             generations=30,
             elite_callback=elite_callback,
         )

--- a/motep/optimizers/ideal.py
+++ b/motep/optimizers/ideal.py
@@ -3,34 +3,29 @@
 from typing import Any
 
 import numpy as np
-import numpy.typing as npt
 from scipy.optimize._optimize import OptimizeResult
 
-from motep.optimizers.base import ParallelOptimizerBase
+from motep.optimizers.base import OptimizerBase
 from motep.optimizers.scipy import Callback
 
 
-class NoInteractionOptimizer(ParallelOptimizerBase):
+class NoInteractionOptimizer(OptimizerBase):
     """Optimizer assuming no atomic interaction."""
 
-    def _optimize(self, **kwargs: dict[str, Any]) -> npt.NDArray[np.float64]:
+    def optimize(self, **kwargs: dict[str, Any]) -> None:
         """Optimize `species_coeffs`.
 
         The values are determined using the least-square method.
         Note that, if there are no composition varieties in the training set,
         the values are physically less meaningful.
 
-        Returns
-        -------
-        npt.NDArray[np.float64]
-
         """
         parameters = self.loss.mtp_data.parameters
         callback = Callback(self.loss)
 
         # Calculate basis functions of `loss.images`
-        loss_value = self.rank0_loss(parameters)
-        self.rank0_gather_data()
+        loss_value = self.loss(parameters)
+        self.loss.gather_data()
 
         # Print the value of the loss function.
         callback(OptimizeResult(x=parameters, fun=loss_value))
@@ -50,12 +45,10 @@ class NoInteractionOptimizer(ParallelOptimizerBase):
         parameters = self.loss.mtp_data.parameters
 
         # Evaluate loss with the new parameters
-        loss_value = self.rank0_loss(parameters)
+        loss_value = self.loss(parameters)
 
         # Print the value of the loss function.
         callback(OptimizeResult(x=parameters, fun=loss_value))
-
-        return parameters
 
     @property
     def optimized_default(self) -> list[str]:

--- a/motep/optimizers/level2mtp.py
+++ b/motep/optimizers/level2mtp.py
@@ -45,7 +45,7 @@ class Level2MTPOptimizer(LLSOptimizerBase):
         callback(OptimizeResult(x=parameters, fun=loss_value))
 
         # Prepare and solve the LLS problem
-        if self.comm.rank == 0:
+        if self.loss.comm.rank == 0:
             logger.debug("Calculate `matrix`")
             matrix = self._calc_matrix()
             logger.debug("Calculate `vector`")
@@ -54,7 +54,7 @@ class Level2MTPOptimizer(LLSOptimizerBase):
             coeffs = np.linalg.lstsq(matrix, vector, rcond=None)[0]
         else:
             coeffs = None
-        coeffs = self.comm.bcast(coeffs, root=0)
+        coeffs = self.loss.comm.bcast(coeffs, root=0)
 
         # Update `mtp_data` and `parameters`.
         parameters = self._update_parameters(coeffs)

--- a/motep/optimizers/level2mtp.py
+++ b/motep/optimizers/level2mtp.py
@@ -5,7 +5,6 @@ from math import sqrt
 from typing import Any
 
 import numpy as np
-import numpy.typing as npt
 from scipy.optimize._optimize import OptimizeResult
 
 from motep.optimizers.lls import LLSOptimizerBase
@@ -34,35 +33,37 @@ class Level2MTPOptimizer(LLSOptimizerBase):
     def optimized_allowed(self) -> list[str]:
         return ["species_coeffs", "radial_coeffs"]
 
-    def _optimize(self, **kwargs: dict[str, Any]) -> npt.NDArray[np.float64]:
+    def optimize(self, **kwargs: dict[str, Any]) -> None:
         parameters = self.loss.mtp_data.parameters
         callback = Callback(self.loss)
 
         # Calculate basis functions of `loss.images`
-        loss_value = self.rank0_loss(parameters)
-        self.rank0_gather_data()
+        loss_value = self.loss(parameters)
+        self.loss.gather_data()
 
         # Print the value of the loss function.
         callback(OptimizeResult(x=parameters, fun=loss_value))
 
         # Prepare and solve the LLS problem
-        logger.debug("Calculate `matrix`")
-        matrix = self._calc_matrix()
-        logger.debug("Calculate `vector`")
-        vector = self._calc_vector()
-        logger.debug("Calculate `coeffs`")
-        coeffs = np.linalg.lstsq(matrix, vector, rcond=None)[0]
+        if self.comm.rank == 0:
+            logger.debug("Calculate `matrix`")
+            matrix = self._calc_matrix()
+            logger.debug("Calculate `vector`")
+            vector = self._calc_vector()
+            logger.debug("Calculate `coeffs`")
+            coeffs = np.linalg.lstsq(matrix, vector, rcond=None)[0]
+        else:
+            coeffs = None
+        coeffs = self.comm.bcast(coeffs, root=0)
 
         # Update `mtp_data` and `parameters`.
         parameters = self._update_parameters(coeffs)
 
         # Evaluate loss with the new parameters
-        loss_value = self.rank0_loss(parameters)
+        loss_value = self.loss(parameters)
 
         # Print the value of the loss function.
         callback(OptimizeResult(x=parameters, fun=loss_value))
-
-        return parameters
 
     def _update_parameters(self, coeffs: np.ndarray) -> np.ndarray:
         mtp_data = self.loss.mtp_data

--- a/motep/optimizers/lls.py
+++ b/motep/optimizers/lls.py
@@ -11,14 +11,14 @@ from ase.stress import voigt_6_to_full_3x3_stress
 from scipy.optimize._optimize import OptimizeResult
 
 from motep.loss import LossFunctionBase
-from motep.optimizers.base import ParallelOptimizerBase
+from motep.optimizers.base import OptimizerBase
 from motep.optimizers.scipy import Callback
 from motep.potentials.mtp.data import get_types
 
 logger = logging.getLogger(__name__)
 
 
-class LLSOptimizerBase(ParallelOptimizerBase):
+class LLSOptimizerBase(OptimizerBase):
     """Abstract base class for linear optimizers.
 
     - :class:`LLSOptimizer`
@@ -241,35 +241,37 @@ class LLSOptimizer(LLSOptimizerBase):
     def optimized_allowed(self) -> list[str]:
         return ["species_coeffs", "moment_coeffs"]
 
-    def _optimize(self, **kwargs: dict[str, Any]) -> npt.NDArray[np.float64]:
+    def optimize(self, **kwargs: dict[str, Any]) -> None:
         parameters = self.loss.mtp_data.parameters
         callback = Callback(self.loss)
 
         # Calculate basis functions of `loss.images`
-        loss_value = self.rank0_loss(parameters)
-        self.rank0_gather_data()
+        loss_value = self.loss(parameters)
+        self.loss.gather_data()
 
         # Print the value of the loss function.
         callback(OptimizeResult(x=parameters, fun=loss_value))
 
         # Prepare and solve the LLS problem
-        logger.debug("Calculate `matrix`")
-        matrix = self._calc_matrix()
-        logger.debug("Calculate `vector`")
-        vector = self._calc_vector()
-        logger.debug("Calculate `coeffs`")
-        coeffs = np.linalg.lstsq(matrix, vector, rcond=None)[0]
+        if self.comm.rank == 0:
+            logger.debug("Calculate `matrix`")
+            matrix = self._calc_matrix()
+            logger.debug("Calculate `vector`")
+            vector = self._calc_vector()
+            logger.debug("Calculate `coeffs`")
+            coeffs = np.linalg.lstsq(matrix, vector, rcond=None)[0]
+        else:
+            coeffs = None
+        coeffs = self.comm.bcast(coeffs, root=0)
 
         # Update `mtp_data` and `parameters`
         parameters = self._update_parameters(coeffs)
 
         # Evaluate loss with the new parameters
-        loss_value = self.rank0_loss(parameters)
+        loss_value = self.loss(parameters)
 
         # Print the value of the loss function.
         callback(OptimizeResult(x=parameters, fun=loss_value))
-
-        return parameters
 
     def _update_parameters(self, coeffs: np.ndarray) -> np.ndarray:
         mtp_data = self.loss.mtp_data

--- a/motep/optimizers/lls.py
+++ b/motep/optimizers/lls.py
@@ -253,7 +253,7 @@ class LLSOptimizer(LLSOptimizerBase):
         callback(OptimizeResult(x=parameters, fun=loss_value))
 
         # Prepare and solve the LLS problem
-        if self.comm.rank == 0:
+        if self.loss.comm.rank == 0:
             logger.debug("Calculate `matrix`")
             matrix = self._calc_matrix()
             logger.debug("Calculate `vector`")
@@ -262,7 +262,7 @@ class LLSOptimizer(LLSOptimizerBase):
             coeffs = np.linalg.lstsq(matrix, vector, rcond=None)[0]
         else:
             coeffs = None
-        coeffs = self.comm.bcast(coeffs, root=0)
+        coeffs = self.loss.comm.bcast(coeffs, root=0)
 
         # Update `mtp_data` and `parameters`
         parameters = self._update_parameters(coeffs)

--- a/motep/optimizers/randomizer.py
+++ b/motep/optimizers/randomizer.py
@@ -3,15 +3,14 @@
 from typing import Any
 
 import numpy as np
-import numpy.typing as npt
 from scipy.optimize._optimize import OptimizeResult
 
 from motep.loss import LossFunctionBase
-from motep.optimizers.base import ParallelOptimizerBase
+from motep.optimizers.base import OptimizerBase
 from motep.optimizers.scipy import Callback
 
 
-class Randomizer(ParallelOptimizerBase):
+class Randomizer(OptimizerBase):
     """Special `Optimizer` class that actually randomizes parameters."""
 
     def __init__(
@@ -35,14 +34,14 @@ class Randomizer(ParallelOptimizerBase):
     def optimized_allowed(self) -> list[str]:
         return ["species_coeffs", "radial_coeffs", "moment_coeffs"]
 
-    def _optimize(self, **kwargs: dict[str, Any]) -> npt.NDArray[np.float64]:
+    def optimize(self, **kwargs: dict[str, Any]) -> None:
         parameters = self.loss.mtp_data.parameters
         callback = Callback(self.loss)
         rng: np.random.Generator = self.loss.setting["rng"]
 
         # Calculate basis functions of `loss.images`
-        loss_value = self.rank0_loss(parameters)
-        self.rank0_gather_data()
+        loss_value = self.loss(parameters)
+        self.loss.gather_data()
 
         # Print the value of the loss function.
         callback(OptimizeResult(x=parameters, fun=loss_value))
@@ -57,9 +56,7 @@ class Randomizer(ParallelOptimizerBase):
         parameters = mtp_data.parameters
 
         # Evaluate loss with the new parameters
-        loss_value = self.rank0_loss(parameters)
+        loss_value = self.loss(parameters)
 
         # Print the value of the loss function.
         callback(OptimizeResult(x=parameters, fun=loss_value))
-
-        return parameters


### PR DESCRIPTION
# Summary

This PR suggests using normal `OptimizerBase` again (rather than `ParallelOptimizerBase`) for non-SciPy optimizers in order to address the issue in `Level2MTPOptimizer` described below.

# Details

I found that, the loss function value printed from `Level2MTPOptimizer` differs when I run the code in parallel using `mpirun`. After survey, I found this comes likely from [`Level2MTPOptimizer._update_parameters`](https://github.com/imw-md/motep/blob/v0.1.0/motep/optimizers/level2mtp.py#L75-L76). Specifically, while `Level2MTPOptimizer` does not optimize `moment_coeffs`, it initializes these coefficients. In the present version (`v0.1.0`), however, this runs only in the Rank 0 process and never transferred to the other processes; `loss.__call__` only transfers the optimized `parameters`. As a result, non-updated (thus random) `moment_coeffs` are used in non-rank-0 processes, causing unreasonable loss function values.

One approach is to implement another method in `ParallelOptimizerBase` to transfer all the parameters in `MTPData`. This however further increases the complexity of `ParallelOptimizerBase`, and I get afraid that soon I cannot very well follow the algorithm.

In the present PR, therefore, I suggest another approach; we revert non SciPy optimizers before the implmentation of https://github.com/imw-md/motep/pull/64.
Since `Level2MTPOptimizer._update_parameters` runs on all processes again, the update of `moment_coeffs` is done on all the processes. For SciPy optimizers, they still inherit `ParallelOptimizerBase`, so the issue in #64 is not reverted.

@axefor Is this reversion acceptable for you? 