### PR TITLE
Add "mgrad" to default minimized properties in LLSOptimizerBase

### DIFF
--- a/motep/optimizers/lls.py
+++ b/motep/optimizers/lls.py
@@ -42,7 +42,7 @@ class LLSOptimizerBase(ParallelOptimizerBase):
         """Initialize the optimizer."""
         super().__init__(loss=loss, **kwargs)
         if minimized is None:
-            minimized = ["energy", "forces", "stress"]
+            minimized = ["energy", "forces", "stress", "mgrad"]
         self.minimized = minimized
 
     @abstractmethod

--- a/motep/optimizers/lls.py
+++ b/motep/optimizers/lls.py
@@ -28,7 +28,8 @@ class LLSOptimizerBase(ParallelOptimizerBase):
     ----------
     minimized : list[str]
         Properties whose errors are minimized by optimizing `radial_coeffs`.
-        The elements must be some of `energy`, `forces`, and `stress`.
+        The elements must be some of `energy`, `forces`, `stress`, and `mgrad`
+        (if magnetic).
 
     """
 

--- a/motep/optimizers/lls.py
+++ b/motep/optimizers/lls.py
@@ -27,9 +27,10 @@ class LLSOptimizerBase(ParallelOptimizerBase):
     Attributes
     ----------
     minimized : list[str]
-        Properties whose errors are minimized by optimizing `radial_coeffs`.
-        The elements must be some of `energy`, `forces`, `stress`, and `mgrad`
-        (if magnetic).
+        Properties whose errors are minimized. The elements must be some of
+        ``energy``, ``forces``, ``stress``, and ``mgrad`` (magnetic moment
+        gradients, for magnetic potentials).
+        Default: ``["energy", "forces", "stress", "mgrad"]``.
 
     """
 


### PR DESCRIPTION
Include "mgrad" as default in the minimized properties for the LLSOptimizerBase class. This should not have an impact unless idcs_mgd is non-zero, in which case the suggested default should be more natural.