### PR TITLE
Add `optimized_always` to `OptimizerBase`

### DIFF
--- a/motep/optimizers/base.py
+++ b/motep/optimizers/base.py
@@ -31,8 +31,7 @@ class OptimizerBase(ABC):
     def __init__(
         self,
         loss: LossFunctionBase,
-        *,
-        optimized: list[str] | None = None,
+        **kwargs,
     ) -> None:
         """Initialize the `Optimizer` class.
 
@@ -40,8 +39,8 @@ class OptimizerBase(ABC):
         ----------
         loss : :class:`motep.loss.LossFunction`
             :class:`motep.loss.LossFunction` object.
-        optimized : list[str]
-            Parameters to be optimized.
+        **kwargs
+            Options passed to the `Optimizer` class.
 
         Raises
         ------
@@ -50,13 +49,15 @@ class OptimizerBase(ABC):
         """
         self.loss = loss
 
-        self.optimized = self.optimized_default if optimized is None else optimized
-        if not all(_ in self.optimized_allowed for _ in self.optimized):
+        optimized: list[str] | None = kwargs.get("optimized")
+        if optimized is None:
+            optimized = self.optimized_default.copy()
+        if not all(_ in self.optimized_allowed for _ in optimized):
             msg = f"Some keywords cannot be optimized with {__name__}."
             raise ValueError(msg)
 
         # add always optimized parameters
-        self.optimized += self.optimized_always
+        self.optimized = optimized + self.optimized_always
 
         # avoid duplication of parameters
         self.optimized = sorted(set(self.optimized), key=self.optimized.index)

--- a/motep/optimizers/base.py
+++ b/motep/optimizers/base.py
@@ -8,7 +8,6 @@ import numpy as np
 import numpy.typing as npt
 
 from motep.loss import LossFunctionBase
-from motep.parallel import DummyMPIComm, world
 
 logger = logging.getLogger(__name__)
 
@@ -33,8 +32,7 @@ class OptimizerBase(ABC):
         self,
         loss: LossFunctionBase,
         *,
-        comm: DummyMPIComm = world,
-        **kwargs: dict[str, Any],
+        optimized: list[str] | None = None,
     ) -> None:
         """Initialize the `Optimizer` class.
 
@@ -42,10 +40,8 @@ class OptimizerBase(ABC):
         ----------
         loss : :class:`motep.loss.LossFunction`
             :class:`motep.loss.LossFunction` object.
-        comm : MPI.Comm
-            MPI.Comm object.
-        **kwargs : dict[str, Any]
-            Options passed to the `Optimizer` class.
+        optimized : list[str]
+            Parameters to be optimized.
 
         Raises
         ------
@@ -53,15 +49,17 @@ class OptimizerBase(ABC):
 
         """
         self.loss = loss
-        self.comm = comm
 
-        if "optimized" not in kwargs:
-            self.optimized = self.optimized_default
-        elif all(_ in self.optimized_allowed for _ in kwargs["optimized"]):
-            self.optimized = kwargs["optimized"]
-        else:
-            msg = f"Some keywords cannot be optimized in {__name__}."
+        self.optimized = self.optimized_default if optimized is None else optimized
+        if not all(_ in self.optimized_allowed for _ in self.optimized):
+            msg = f"Some keywords cannot be optimized with {__name__}."
             raise ValueError(msg)
+
+        # add always optimized parameters
+        self.optimized += self.optimized_always
+
+        # avoid duplication of parameters
+        self.optimized = sorted(set(self.optimized), key=self.optimized.index)
 
         self.loss.mtp_data.optimized = self.optimized
 
@@ -78,6 +76,11 @@ class OptimizerBase(ABC):
     @abstractmethod
     def optimized_allowed(self) -> list[str]:
         """Return allowed `optimized`."""
+
+    @property
+    def optimized_always(self) -> list[str]:
+        """Parameters optimized always regardless they are specified or not."""
+        return []
 
 
 class ParallelOptimizerBase(OptimizerBase):

--- a/motep/optimizers/base.py
+++ b/motep/optimizers/base.py
@@ -51,7 +51,7 @@ class OptimizerBase(ABC):
 
         optimized: list[str] | None = kwargs.get("optimized")
         if optimized is None:
-            optimized = self.optimized_default.copy()
+            optimized = self.optimized_default
         if not all(_ in self.optimized_allowed for _ in optimized):
             msg = f"Some keywords cannot be optimized with {__name__}."
             raise ValueError(msg)

--- a/motep/optimizers/level2mtp.py
+++ b/motep/optimizers/level2mtp.py
@@ -17,22 +17,22 @@ logger = logging.getLogger(__name__)
 class Level2MTPOptimizer(LLSOptimizerBase):
     """Optimizer for Level 2 MTP.
 
-    The elements of the ``optimized`` attribute must be:
-
-    - ``species_coeffs``
-    - ``radial_coeffs``
-
-    ``moment_coeffs`` cannot be optimized with this optimizer.
+    ``moment_coeffs`` and ``radial_coeffs`` are automatically set to be a level 2 MTP.
+    Further, ``species_coeffs`` can also be optimized.
 
     """
 
     @property
     def optimized_default(self) -> list[str]:
-        return ["species_coeffs", "radial_coeffs"]
+        return ["scaling", "species_coeffs", "moment_coeffs", "radial_coeffs"]
 
     @property
     def optimized_allowed(self) -> list[str]:
-        return ["species_coeffs", "radial_coeffs"]
+        return ["scaling", "species_coeffs", "moment_coeffs", "radial_coeffs"]
+
+    @property
+    def optimized_always(self) -> list[str]:
+        return ["scaling", "moment_coeffs", "radial_coeffs"]
 
     def _optimize(self, **kwargs: dict[str, Any]) -> npt.NDArray[np.float64]:
         parameters = self.loss.mtp_data.parameters

--- a/motep/train/trainer.py
+++ b/motep/train/trainer.py
@@ -127,7 +127,8 @@ class Trainer:
                     self.mtp_data.log()
 
                 # Instantiate an `Optimizer` class
-                optimizer: OptimizerBase = make_optimizer(step["method"])(loss, **step)
+                optimizer_class = make_optimizer(step["method"])
+                optimizer = optimizer_class(loss, optimized=step.get("optimized"))
                 optimizer.optimize(**step.get("kwargs", {}))
                 loss.broadcast_results()
                 if self.comm.rank == 0:

--- a/motep/train/trainer.py
+++ b/motep/train/trainer.py
@@ -128,7 +128,7 @@ class Trainer:
 
                 # Instantiate an `Optimizer` class
                 optimizer_class = make_optimizer(step["method"])
-                optimizer = optimizer_class(loss, optimized=step.get("optimized"))
+                optimizer = optimizer_class(loss, **step)
                 optimizer.optimize(**step.get("kwargs", {}))
                 loss.broadcast_results()
                 if self.comm.rank == 0:

--- a/tests/optimizers/test_scipy.py
+++ b/tests/optimizers/test_scipy.py
@@ -67,7 +67,7 @@ def test_scaling_vs_jac(data_path: pathlib.Path) -> None:
 
     step = {"method": "L-BFGS-B", "kwargs": {"jac": True, "options": {"maxiter": 10}}}
 
-    optimizer = ScipyMinimizeOptimizer(loss, optimized=optimized)
+    optimizer = ScipyMinimizeOptimizer(loss, optimized=optimized, **step)
 
     with pytest.raises(ValueError, match="scaling"):
         optimizer.optimize(**step.get("kwargs", {}))

--- a/tests/optimizers/test_scipy.py
+++ b/tests/optimizers/test_scipy.py
@@ -67,7 +67,7 @@ def test_scaling_vs_jac(data_path: pathlib.Path) -> None:
 
     step = {"method": "L-BFGS-B", "kwargs": {"jac": True, "options": {"maxiter": 10}}}
 
-    optimizer = ScipyMinimizeOptimizer(loss, optimized=optimized, **step)
+    optimizer = ScipyMinimizeOptimizer(loss, optimized=optimized)
 
     with pytest.raises(ValueError, match="scaling"):
         optimizer.optimize(**step.get("kwargs", {}))


### PR DESCRIPTION
This PR addresses the issue in `Level2MTPOptimizer` during parallel calculations described in #104 in a different way, by including `moment_coeffs` in `optimized`, so that it can be passed to different processes via `parameters`. To make it systematic, I have introduced the `optimized_always` property so that `moment_coeffs` are included always for `Level2MTLPOptimizer`.

A few minor changes are also done for `OptimizerBase` for cleanup.

- `comm` is removed, in favor of accessing it via `loss` (@axefor Is this reasonable?)
- `optimized` is explicitly set as an keyword-only argument instead of via `**kwargs`

closes #104