### PR TITLE
Print down to DEBUG level log calls with pytest.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Common setting for pytest."""
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -27,3 +28,15 @@ def doc_path() -> Path:
 
     """
     return Path(__file__).parents[1] / "docs"
+
+
+def pytest_configure(config) -> None:
+    """Configure pytest."""
+    logging.getLogger("motep").setLevel(logging.DEBUG)
+
+
+def pytest_collection_modifyitems(items) -> None:
+    """Set DEBUG level on all test_* loggers after collection."""
+    for name in logging.root.manager.loggerDict:
+        if name.startswith("test_"):
+            logging.getLogger(name).setLevel(logging.DEBUG)


### PR DESCRIPTION
This PR aims to print log messages to the DEBUG level when a test fails.

I thought this is handy while testing, what do you think @yuzie007 ? I'm not sure this is the best technical solution, but it seems to work :) 

It should probably be merged after #106 .