### PR TITLE
Fix magnetic moments handling and enforce size attribute type in BasisData

### DIFF
--- a/motep/io/mlip/cfg.py
+++ b/motep/io/mlip/cfg.py
@@ -159,8 +159,8 @@ def _set_magmoms(atoms: Atoms, atomdata: dict) -> None:
     magmoms = list(zip(*[atomdata.get(_, [0.0] * n) for _ in keys], strict=True))
     magmoms = np.array(magmoms)
     cols = np.where(~(magmoms == 0).all(axis=0))[0]
-    if len(cols) == 1:
-        magmoms = magmoms[:, cols[0]]
+    if len(cols) <= 1:
+        magmoms = magmoms[:, cols[0]] if len(cols) == 1 else np.zeros(n)
     atoms.calc.results["magmoms"] = magmoms
 
 

--- a/motep/potentials/mmtp/base.py
+++ b/motep/potentials/mmtp/base.py
@@ -17,6 +17,47 @@ from motep.potentials.mtp.base import (
 from .data import MagMTPData
 
 
+def _ensure_collinear_magmoms(
+    atoms: Atoms, magmoms: npt.NDArray[np.float64] | None = None
+) -> npt.NDArray[np.float64]:
+    """Ensure magnetic moments are a 1D collinear array.
+
+    Parameters
+    ----------
+    atoms : Atoms
+        The atomic structure.
+    magmoms : np.ndarray or None
+        Magnetic moments. If None, reads from
+        ``atoms.get_initial_magnetic_moments()``.
+
+    Returns
+    -------
+    1D array of scalar magnetic moments.
+
+    Raises
+    ------
+    ValueError
+        If 2D magmoms have more than one non-zero component (non-collinear).
+
+    """
+    if magmoms is None:
+        magmoms = atoms.get_initial_magnetic_moments()
+    if magmoms.ndim == 2:
+        nonzero_cols = np.where(~(magmoms == 0).all(axis=0))[0]
+        if len(nonzero_cols) > 1:
+            msg = (
+                "Non-collinear magnetic moments (multiple non-zero "
+                "components) are not supported. Got non-zero columns: "
+                f"{nonzero_cols.tolist()}"
+            )
+            raise ValueError(msg)
+        if len(nonzero_cols) == 1:
+            magmoms = magmoms[:, nonzero_cols[0]]
+        else:
+            magmoms = np.zeros(magmoms.shape[0])
+    return np.asarray(magmoms, dtype=np.float64)
+
+
 class MagModeBase(ModeBase):
     """Base mode class for magnetic MTPs defining available operation modes."""
 
@@ -158,6 +199,8 @@ class MagEngineBase(MagModeBase, EngineBase):
         if self.update_neighbor_list(atoms):
             self.initialize_basis_data(atoms)
 
+        magmoms = _ensure_collinear_magmoms(atoms, magmoms)
+
         energies, forces, stress, mgrad = self._calculate(atoms, magmoms=magmoms)
 
         self._symmetrize_stress(atoms, stress)
@@ -209,8 +252,7 @@ class MagEngineBase(MagModeBase, EngineBase):
             Results dictionary including relaxed ``magmoms`` and ``magmom``.
 
         """
-        if magmoms_init is None:
-            magmoms_init = atoms.get_initial_magnetic_moments()
+        magmoms_init = _ensure_collinear_magmoms(atoms, magmoms_init)
         mtp_data = self.mtp_data
 
         self.check_species(atoms)

--- a/motep/potentials/mmtp/cext/engine.py
+++ b/motep/potentials/mmtp/cext/engine.py
@@ -25,10 +25,8 @@ class CExtMagMTPEngine(MagEngineBase):
     but uses compiled C code for better performance in some scenarios.
     """
 
-    def _calculate(self, atoms: Atoms, magmoms: np.ndarray | None = None) -> tuple:
+    def _calculate(self, atoms: Atoms, magmoms: np.ndarray) -> tuple:
         """Main calculation dispatch."""
-        if magmoms is None:
-            magmoms = atoms.get_initial_magnetic_moments()
         if self.mode == "run":
             return self._calc_mag_run(atoms, magmoms)
         if self.mode == "train":

--- a/motep/potentials/mmtp/numba/engine.py
+++ b/motep/potentials/mmtp/numba/engine.py
@@ -18,9 +18,9 @@ from motep.potentials.mtp.numba.moment import (
     store_radial_basis,
     update_mbd_dbdeps,
     update_mbd_dbdris,
-    update_mbd_dvdcs,
     update_mbd_dgdcs,
     update_mbd_dsdcs,
+    update_mbd_dvdcs,
     update_mbd_vatoms,
 )
 
@@ -37,9 +37,7 @@ from .moment import (
 class NumbaMagMTPEngine(MagEngineBase):
     """MTP Engine based on Numba."""
 
-    def _calculate(self, atoms: Atoms, magmoms: np.ndarray | None = None) -> tuple:
-        if magmoms is None:
-            magmoms = atoms.get_initial_magnetic_moments()
+    def _calculate(self, atoms: Atoms, magmoms: np.ndarray) -> tuple:
         if self.mode == "run":
             return self._calc_mag_run(atoms, magmoms)
         if self.mode == "train":

--- a/motep/potentials/mtp/data.py
+++ b/motep/potentials/mtp/data.py
@@ -44,6 +44,11 @@ class BasisData:
     max: np.float64 = field(default_factory=lambda: np.float64(np.nan))
     size: np.int32 = field(default_factory=lambda: np.int32(0))
 
+    def __setattr__(self, name: str, value: object) -> None:
+        if name == "size":
+            value = np.int32(value)
+        super().__setattr__(name, value)
+
     def __post_init__(self) -> None:
         """Validate basis parameters.
 

--- a/tests/potentials/mmtp/test_engines.py
+++ b/tests/potentials/mmtp/test_engines.py
@@ -16,6 +16,35 @@ from motep.potentials.mmtp.cext.engine import CExtMagMTPEngine
 from motep.potentials.mmtp.numba.engine import NumbaMagMTPEngine
 
 
+@pytest.fixture
+def mag_engine_and_atoms(data_path: pathlib.Path):
+    path = data_path / "original/mag"
+    mtp_path = path / "02.mmtp"
+    if not mtp_path.exists():
+        pytest.skip(f"Data file {mtp_path} not found")
+    mtp_data = read_mmtp(mtp_path)
+    engine = NumbaMagMTPEngine(mtp_data)
+    atoms = read_cfg(path / "mag.cfg", index=-1)
+    atoms.set_initial_magnetic_moments(atoms.get_magnetic_moments())
+    return engine, atoms
+
+
+class TestCollinearMagmoms:
+    def test_2d_all_zero_columns_accepted(self, mag_engine_and_atoms) -> None:
+        engine, atoms = mag_engine_and_atoms
+        magmoms_2d = np.zeros((len(atoms), 3))
+        result = engine.calculate(atoms, magmoms=magmoms_2d)
+        assert "energy" in result
+
+    def test_2d_noncollinear_raises(self, mag_engine_and_atoms) -> None:
+        engine, atoms = mag_engine_and_atoms
+        magmoms_2d = np.zeros((len(atoms), 3))
+        magmoms_2d[:, 0] = 1.0
+        magmoms_2d[:, 2] = 1.0
+        with pytest.raises(ValueError, match="Non-collinear"):
+            engine.calculate(atoms, magmoms=magmoms_2d)
+
+
 @pytest.mark.parametrize("level", [2, 4, 6, 8, 10])
 @pytest.mark.parametrize("mode", ["run", "train", "train_mgrad"])
 @pytest.mark.parametrize("engine_class", [CExtMagMTPEngine])


### PR DESCRIPTION
Improve handling of magnetic moments by accommodating cases with no non-zero columns and ensuring collinearity. Enforce the size attribute type in BasisData to be np.int32 during assignment.