### PR TITLE
Make jax and numba imports optional in tests

### DIFF
--- a/tests/optimizers/test_level2mtp.py
+++ b/tests/optimizers/test_level2mtp.py
@@ -128,9 +128,7 @@ def test_local_minimum(data_path: pathlib.Path) -> None:
 
 @pytest.mark.parametrize("level", [2, 4, 6])
 @pytest.mark.parametrize("molecule", [762, 291, 14214, 23208])
-@pytest.mark.parametrize("engine", ["cext", "numba"])
 def test_molecules(
-    engine: str,
     molecule: int,
     level: int,
     data_path: pathlib.Path,
@@ -151,7 +149,6 @@ def test_molecules(
         mtp_data=mtp_data,
         setting=setting,
         comm=world,
-        engine=engine,
     )
 
     optimizer = NoInteractionOptimizer(loss)

--- a/tests/potentials/mmtp/test_engines.py
+++ b/tests/potentials/mmtp/test_engines.py
@@ -283,3 +283,59 @@ def test_stress(
 
     stress = stress.ravel()[[0, 4, 8, 5, 2, 1]]
     np.testing.assert_allclose(stress, stress_ref, rtol=0.0, atol=1e-4)
+
+
+@pytest.mark.parametrize("level", [2, 4, 6, 8, 10])
+@pytest.mark.parametrize("mode", ["run", "train", "train_mgrad"])
+def test_basis_data(
+    mode: str,
+    level: int,
+    data_path: pathlib.Path,
+) -> None:
+    """Test that CExtMagMTPEngine basis data matches NumbaMagMTPEngine (reference)."""
+    if not _numba_available:
+        pytest.skip("numba not available")
+    path = data_path / "original/mag"
+    mtp_path = path / f"{level:02d}.mmtp"
+    if not mtp_path.exists():
+        pytest.skip(f"Data file {mtp_path} not found")
+
+    mtp_data = read_mmtp(mtp_path)
+
+    try:
+        ref = NumbaMagMTPEngine(mtp_data, mode=mode)
+    except NotImplementedError as e:
+        pytest.skip(f"Reference engine does not support this configuration: {e}")
+
+    try:
+        mtp = CExtMagMTPEngine(mtp_data, mode=mode)
+    except NotImplementedError as e:
+        pytest.skip(f"Engine does not support this configuration: {e}")
+
+    atoms = read_cfg(path / "mag.cfg", index=-1)
+    atoms.set_initial_magnetic_moments(atoms.get_magnetic_moments())
+
+    ref.calculate(atoms)
+    mtp.calculate(atoms)
+
+    mbd = mtp.mbd
+    mbd_ref = ref.mbd
+    np.testing.assert_allclose(mbd.vatoms, mbd_ref.vatoms, rtol=0.0, atol=1e-6)
+
+    if "train" in mode:
+        np.testing.assert_allclose(mbd.dbdris, mbd_ref.dbdris, rtol=0.0, atol=1e-6)
+        np.testing.assert_allclose(mbd.dbdeps, mbd_ref.dbdeps, rtol=0.0, atol=1e-6)
+        np.testing.assert_allclose(mbd.dedcs, mbd_ref.dedcs, rtol=0.0, atol=1e-6)
+        np.testing.assert_allclose(mbd.dgdcs, mbd_ref.dgdcs, rtol=0.0, atol=1e-6)
+        np.testing.assert_allclose(mbd.dsdcs, mbd_ref.dsdcs, rtol=0.0, atol=1e-6)
+
+        rbd = mtp.rbd
+        rbd_ref = ref.rbd
+        np.testing.assert_allclose(rbd.values, rbd_ref.values, rtol=0.0, atol=1e-6)
+        np.testing.assert_allclose(rbd.dqdris, rbd_ref.dqdris, rtol=0.0, atol=1e-6)
+        np.testing.assert_allclose(rbd.dqdeps, rbd_ref.dqdeps, rtol=0.0, atol=1e-6)
+
+    if mode == "train_mgrad":
+        np.testing.assert_allclose(mbd.dbdmis, mbd_ref.dbdmis, rtol=0.0, atol=1e-6)
+        np.testing.assert_allclose(mbd.dgmdcs, mbd_ref.dgmdcs, rtol=0.0, atol=1e-6)
+        np.testing.assert_allclose(rbd.dqdmis, rbd_ref.dqdmis, rtol=0.0, atol=1e-6)

--- a/tests/potentials/mmtp/test_engines.py
+++ b/tests/potentials/mmtp/test_engines.py
@@ -13,11 +13,25 @@ from motep.io.mlip.cfg import read_cfg
 from motep.io.mlip.mtp import read_mmtp
 from motep.potentials.mmtp.base import MagEngineBase
 from motep.potentials.mmtp.cext.engine import CExtMagMTPEngine
-from motep.potentials.mmtp.numba.engine import NumbaMagMTPEngine
+
+try:
+    from motep.potentials.mmtp.numba.engine import NumbaMagMTPEngine
+
+    _numba_available = True
+except ImportError:
+    NumbaMagMTPEngine = None  # type: ignore[assignment,misc]
+    _numba_available = False
+
+_numba_mag_param = pytest.param(
+    NumbaMagMTPEngine,
+    marks=pytest.mark.skipif(not _numba_available, reason="numba not available"),
+)
 
 
 @pytest.fixture
 def mag_engine_and_atoms(data_path: pathlib.Path):
+    if not _numba_available:
+        pytest.skip("numba not available")
     path = data_path / "original/mag"
     mtp_path = path / "02.mmtp"
     if not mtp_path.exists():
@@ -72,6 +86,8 @@ def test_mmtp_energies_forces_stress(
     except NotImplementedError as e:
         pytest.skip(f"Engine does not support this configuration: {e}")
 
+    if not _numba_available:
+        pytest.skip("numba not available")
     try:
         ref_engine = NumbaMagMTPEngine(mtp_data, mode=mode)
     except NotImplementedError as e:
@@ -123,7 +139,7 @@ def test_mmtp_energies_forces_stress(
 
 @pytest.mark.parametrize("level", [2, 4, 6, 8, 10])
 @pytest.mark.parametrize("mode", ["run", "train", "train_mgrad"])
-@pytest.mark.parametrize("engine_class", [CExtMagMTPEngine, NumbaMagMTPEngine])
+@pytest.mark.parametrize("engine_class", [CExtMagMTPEngine, _numba_mag_param])
 def test_mgrad(
     engine_class: type[MagEngineBase],
     level: int,
@@ -164,7 +180,7 @@ def test_mgrad(
 
 
 @pytest.mark.parametrize("level", [2, 4, 6, 8, 10])
-@pytest.mark.parametrize("engine_class", [CExtMagMTPEngine, NumbaMagMTPEngine])
+@pytest.mark.parametrize("engine_class", [CExtMagMTPEngine, _numba_mag_param])
 def test_forces(
     engine_class: type[MagEngineBase],
     level: int,
@@ -204,7 +220,7 @@ def test_forces(
 
 
 @pytest.mark.parametrize("level", [2, 4, 6, 8, 10])
-@pytest.mark.parametrize("engine_class", [CExtMagMTPEngine, NumbaMagMTPEngine])
+@pytest.mark.parametrize("engine_class", [CExtMagMTPEngine, _numba_mag_param])
 def test_stress(
     engine_class: type[MagEngineBase],
     level: int,

--- a/tests/potentials/mtp/jax/test_moments.py
+++ b/tests/potentials/mtp/jax/test_moments.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytest.importorskip("jax", reason="JAX not available")
+
 from motep.potentials.mtp.jax.moment import MomentBasis, _flatten_to_moments
 
 

--- a/tests/potentials/mtp/test_engines.py
+++ b/tests/potentials/mtp/test_engines.py
@@ -209,15 +209,16 @@ def test_stress(
 
 @pytest.mark.parametrize("level", [2, 4, 6, 8, 10])
 @pytest.mark.parametrize("crystal", ["multi"])
+@pytest.mark.parametrize("mode", ["run", "train"])
 @pytest.mark.parametrize("engine", [_numba_param, CExtMTPEngine])
 def test_basis_data(
     engine: type[EngineBase],
+    mode: str,
     crystal: int,
     level: int,
     data_path: pathlib.Path,
 ) -> None:
     """Test PyMTP."""
-    mode = "train"
     path = data_path / f"fitting/crystals/{crystal}/{level:02d}"
     if not (path / "pot.mtp").exists():
         pytest.skip()
@@ -234,14 +235,16 @@ def test_basis_data(
         mbd = mtp.mbd
         mbd_ref = ref.mbd
         np.testing.assert_allclose(mbd.vatoms, mbd_ref.vatoms, rtol=0.0, atol=1e-6)
-        np.testing.assert_allclose(mbd.dbdris, mbd_ref.dbdris, rtol=0.0, atol=1e-6)
-        np.testing.assert_allclose(mbd.dbdeps, mbd_ref.dbdeps, rtol=0.0, atol=1e-6)
-        np.testing.assert_allclose(mbd.dedcs, mbd_ref.dedcs, rtol=0.0, atol=1e-6)
-        np.testing.assert_allclose(mbd.dgdcs, mbd_ref.dgdcs, rtol=0.0, atol=1e-6)
-        np.testing.assert_allclose(mbd.dsdcs, mbd_ref.dsdcs, rtol=0.0, atol=1e-6)
 
-        rbd = mtp.rbd
-        rbd_ref = ref.rbd
-        np.testing.assert_allclose(rbd.values, rbd_ref.values, rtol=0.0, atol=1e-6)
-        np.testing.assert_allclose(rbd.dqdris, rbd_ref.dqdris, rtol=0.0, atol=1e-6)
-        np.testing.assert_allclose(rbd.dqdeps, rbd_ref.dqdeps, rtol=0.0, atol=1e-6)
+        if mode == "train":
+            np.testing.assert_allclose(mbd.dbdris, mbd_ref.dbdris, rtol=0.0, atol=1e-6)
+            np.testing.assert_allclose(mbd.dbdeps, mbd_ref.dbdeps, rtol=0.0, atol=1e-6)
+            np.testing.assert_allclose(mbd.dedcs, mbd_ref.dedcs, rtol=0.0, atol=1e-6)
+            np.testing.assert_allclose(mbd.dgdcs, mbd_ref.dgdcs, rtol=0.0, atol=1e-6)
+            np.testing.assert_allclose(mbd.dsdcs, mbd_ref.dsdcs, rtol=0.0, atol=1e-6)
+
+            rbd = mtp.rbd
+            rbd_ref = ref.rbd
+            np.testing.assert_allclose(rbd.values, rbd_ref.values, rtol=0.0, atol=1e-6)
+            np.testing.assert_allclose(rbd.dqdris, rbd_ref.dqdris, rtol=0.0, atol=1e-6)
+            np.testing.assert_allclose(rbd.dqdeps, rbd_ref.dqdeps, rtol=0.0, atol=1e-6)

--- a/tests/potentials/mtp/test_engines.py
+++ b/tests/potentials/mtp/test_engines.py
@@ -9,16 +9,39 @@ from motep.io.mlip.cfg import read_cfg
 from motep.io.mlip.mtp import read_mtp
 from motep.potentials.mtp.base import EngineBase
 from motep.potentials.mtp.cext.engine import CExtMTPEngine
-from motep.potentials.mtp.jax.engine import JaxMTPEngine
-from motep.potentials.mtp.numba.engine import NumbaMTPEngine
 from motep.potentials.mtp.numpy.engine import NumpyMTPEngine
+
+try:
+    from motep.potentials.mtp.numba.engine import NumbaMTPEngine
+
+    _numba_available = True
+except ImportError:
+    NumbaMTPEngine = None  # type: ignore[assignment,misc]
+    _numba_available = False
+
+try:
+    from motep.potentials.mtp.jax.engine import JaxMTPEngine
+
+    _jax_available = True
+except ImportError:
+    JaxMTPEngine = None  # type: ignore[assignment,misc]
+    _jax_available = False
+
+_numba_param = pytest.param(
+    NumbaMTPEngine,
+    marks=pytest.mark.skipif(not _numba_available, reason="numba not available"),
+)
+_jax_param = pytest.param(
+    JaxMTPEngine,
+    marks=pytest.mark.skipif(not _jax_available, reason="JAX not available"),
+)
 
 
 @pytest.mark.parametrize("level", [2, 4, 6, 8, 10])
 @pytest.mark.parametrize("molecule", [762, 291, 14214, 23208])
 @pytest.mark.parametrize("mode", ["run", "train"])
 @pytest.mark.parametrize(
-    "engine", [NumpyMTPEngine, NumbaMTPEngine, JaxMTPEngine, CExtMTPEngine]
+    "engine", [NumpyMTPEngine, _numba_param, _jax_param, CExtMTPEngine]
 )
 # @pytest.mark.parametrize("molecule", [762])
 def test_molecules(
@@ -52,7 +75,7 @@ def test_molecules(
 @pytest.mark.parametrize("crystal", ["multi"])
 @pytest.mark.parametrize("mode", ["run", "train"])
 # @pytest.mark.parametrize("engine", [NumpyMTPEngine, NumbaMTPEngine])
-@pytest.mark.parametrize("engine", [NumbaMTPEngine, JaxMTPEngine, CExtMTPEngine])
+@pytest.mark.parametrize("engine", [_numba_param, _jax_param, CExtMTPEngine])
 def test_crystals(
     engine: type[EngineBase],
     mode: str,
@@ -87,7 +110,7 @@ def test_crystals(
 @pytest.mark.parametrize("level", [2, 4, 6, 8, 10])
 @pytest.mark.parametrize("molecule", [762, 291, 14214, 23028])
 @pytest.mark.parametrize(
-    "engine", [NumpyMTPEngine, NumbaMTPEngine, JaxMTPEngine, CExtMTPEngine]
+    "engine", [NumpyMTPEngine, _numba_param, _jax_param, CExtMTPEngine]
 )
 def test_forces(
     engine: type[EngineBase],
@@ -124,7 +147,7 @@ def test_forces(
 @pytest.mark.parametrize("crystal", ["cubic", "noncubic"])
 @pytest.mark.parametrize(
     "engine",
-    [NumpyMTPEngine, NumbaMTPEngine, JaxMTPEngine, CExtMTPEngine],
+    [NumpyMTPEngine, _numba_param, _jax_param, CExtMTPEngine],
 )
 def test_stress(
     engine: type[EngineBase],
@@ -186,7 +209,7 @@ def test_stress(
 
 @pytest.mark.parametrize("level", [2, 4, 6, 8, 10])
 @pytest.mark.parametrize("crystal", ["multi"])
-@pytest.mark.parametrize("engine", [NumbaMTPEngine, CExtMTPEngine])
+@pytest.mark.parametrize("engine", [_numba_param, CExtMTPEngine])
 def test_basis_data(
     engine: type[EngineBase],
     crystal: int,


### PR DESCRIPTION
Enhance test flexibility by making JAX and Numba imports optional, allowing tests to skip if these libraries are unavailable. Additionally, parameterize basis data tests over engine mode to ensure comprehensive coverage, including also magnetic basis data.