### PR TITLE
Add upconverter module and fix Trainer docstring typo

### DIFF
--- a/motep/train/__init__.py
+++ b/motep/train/__init__.py
@@ -1,4 +1,4 @@
-"""Traner."""
+"""Trainer."""
 
 from .trainer import Trainer
 

--- a/motep/upconvert/__init__.py
+++ b/motep/upconvert/__init__.py
@@ -1,0 +1,5 @@
+"""Upconverter."""
+
+from .upconverter import upconvert
+
+__all__ = ["upconvert"]


### PR DESCRIPTION
Import upconvert in `upconver.__init__.py` allowing to import as
```
from motep.upconvert import upconvert
```
instead of
```
from motep.upconvert.upconverter import upconvert
```
Closes issue #103. 

Additionally correct a typo in the Trainer docstring.