### PR TITLE
Remove -march and -ffast-math from meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,9 +5,7 @@ project(
 )
 
 add_project_arguments(
-  '-O3',
-  '-ffast-math',
-  '-march=native',
+  '-O2',
   language: 'c',
 )
 

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -130,7 +130,8 @@ def test_jac(
 
     assert np.any(jac_nmr)  # check if some of the elements are non-zero
 
-    np.testing.assert_allclose(jac_nmr, jac_anl, rtol=2e-1, atol=1e-12)
+    # Relax tolerance from 1e-12 for analytical Jacobian from CextMTPEngine
+    np.testing.assert_allclose(jac_nmr, jac_anl, rtol=2e-1, atol=1e-10)
 
 
 def test_stress_weight_scaling() -> None:


### PR DESCRIPTION
I've tested different `-march` options and also `-ffast-math` as well as different `-OX` levels on both an Apple Silicon Mac and a Linux work station. In principle there is no difference to only `-O2`, or in the Linux case it's even a bit faster without `-ffast-math`. I therefore suggest to keep only the `-O2` flag.