### PR TITLE
Replace NPY_ARRAY_INOUT_ARRAY with get_inplace_double function

### DIFF
--- a/motep/potentials/mmtp/cext/mmtp_cext_module.c
+++ b/motep/potentials/mmtp/cext/mmtp_cext_module.c
@@ -39,6 +39,21 @@ static int require_inplace_double(PyArrayObject *arr, const char *name)
     return 1;
 }
 
+/* Cast a Python object directly to a writable, C-contiguous float64 array.
+ * Returns a borrowed reference (no copy is ever made). */
+static PyArrayObject *get_inplace_double(PyObject *obj, const char *name)
+{
+    if (!PyArray_Check(obj))
+    {
+        PyErr_Format(PyExc_TypeError, "%s must be a numpy array", name);
+        return NULL;
+    }
+    PyArrayObject *arr = (PyArrayObject *)obj;
+    if (!require_inplace_double(arr, name))
+        return NULL;
+    return arr;
+}
+
 /* ==========================================================================
  * Python wrapper for calc_mag_run
  * ========================================================================== */
@@ -225,20 +240,17 @@ static PyObject *py_calc_mag_run(PyObject *self, PyObject *args, PyObject *kwarg
 
     /* Extract mbd.vatoms for in-place writing */
     PyObject *mbd_vatoms_obj = PyObject_GetAttrString(mbd_obj, "vatoms");
-    PyArrayObject *mbd_vatoms_arr = mbd_vatoms_obj
-                                        ? (PyArrayObject *)PyArray_FROM_OTF(mbd_vatoms_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY)
-                                        : NULL;
+    PyArrayObject *mbd_vatoms_arr = mbd_vatoms_obj ? get_inplace_double(mbd_vatoms_obj, "mbd.vatoms") : NULL;
+    Py_XDECREF(mbd_vatoms_obj);
 
-    if (!energies_arr || !gradient_arr || !grad_mag_i_arr || !grad_mag_j_arr ||
-        !mbd_vatoms_obj || !mbd_vatoms_arr || !require_inplace_double(mbd_vatoms_arr, "mbd.vatoms"))
+    if (!energies_arr || !gradient_arr || !grad_mag_i_arr || !grad_mag_j_arr || !mbd_vatoms_arr)
     {
-        PyErr_SetString(PyExc_MemoryError, "Failed to allocate output arrays");
+        if (!PyErr_Occurred())
+            PyErr_SetString(PyExc_MemoryError, "Failed to allocate output arrays");
         Py_XDECREF(energies_arr);
         Py_XDECREF(gradient_arr);
         Py_XDECREF(grad_mag_i_arr);
         Py_XDECREF(grad_mag_j_arr);
-        Py_XDECREF(mbd_vatoms_arr);
-        Py_XDECREF(mbd_vatoms_obj);
         Py_DECREF(radial_coeffs_arr);
         Py_DECREF(species_coeffs_arr);
         Py_DECREF(alpha_moment_mapping_arr);
@@ -316,8 +328,6 @@ static PyObject *py_calc_mag_run(PyObject *self, PyObject *args, PyObject *kwarg
     Py_DECREF(alpha_index_times_obj);
     Py_DECREF(alpha_index_times_count_obj);
     Py_DECREF(moment_coeffs_obj);
-    Py_DECREF(mbd_vatoms_arr);
-    Py_DECREF(mbd_vatoms_obj);
 
     return Py_BuildValue("(NNNN)", energies_arr, gradient_arr, grad_mag_i_arr, grad_mag_j_arr);
 }
@@ -537,22 +547,31 @@ static PyObject *py_calc_mag_train(PyObject *self, PyObject *args, PyObject *kwa
     PyObject *rbd_values_obj = PyObject_GetAttrString(rbd_obj, "values");
     PyObject *rbd_dqdris_obj = PyObject_GetAttrString(rbd_obj, "dqdris");
     PyObject *rbd_dqdeps_obj = PyObject_GetAttrString(rbd_obj, "dqdeps");
-    PyArrayObject *rbd_values_arr = (PyArrayObject *)PyArray_FROM_OTF(rbd_values_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *rbd_dqdris_arr = (PyArrayObject *)PyArray_FROM_OTF(rbd_dqdris_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *rbd_dqdeps_arr = (PyArrayObject *)PyArray_FROM_OTF(rbd_dqdeps_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-
     PyObject *mbd_vatoms_obj = PyObject_GetAttrString(mbd_obj, "vatoms");
     PyObject *mbd_dbdris_obj = PyObject_GetAttrString(mbd_obj, "dbdris");
     PyObject *mbd_dbdeps_obj = PyObject_GetAttrString(mbd_obj, "dbdeps");
     PyObject *mbd_dvdcs_obj = PyObject_GetAttrString(mbd_obj, "dvdcs");
     PyObject *mbd_dgdcs_obj = PyObject_GetAttrString(mbd_obj, "dgdcs");
     PyObject *mbd_dsdcs_obj = PyObject_GetAttrString(mbd_obj, "dsdcs");
-    PyArrayObject *mbd_vatoms_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_vatoms_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dbdris_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dbdris_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dbdeps_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dbdeps_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dvdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dvdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dgdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dgdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dsdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dsdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
+
+    PyArrayObject *rbd_values_arr = get_inplace_double(rbd_values_obj, "rbd.values");
+    Py_DECREF(rbd_values_obj);
+    PyArrayObject *rbd_dqdris_arr = get_inplace_double(rbd_dqdris_obj, "rbd.dqdris");
+    Py_DECREF(rbd_dqdris_obj);
+    PyArrayObject *rbd_dqdeps_arr = get_inplace_double(rbd_dqdeps_obj, "rbd.dqdeps");
+    Py_DECREF(rbd_dqdeps_obj);
+    PyArrayObject *mbd_vatoms_arr = get_inplace_double(mbd_vatoms_obj, "mbd.vatoms");
+    Py_DECREF(mbd_vatoms_obj);
+    PyArrayObject *mbd_dbdris_arr = get_inplace_double(mbd_dbdris_obj, "mbd.dbdris");
+    Py_DECREF(mbd_dbdris_obj);
+    PyArrayObject *mbd_dbdeps_arr = get_inplace_double(mbd_dbdeps_obj, "mbd.dbdeps");
+    Py_DECREF(mbd_dbdeps_obj);
+    PyArrayObject *mbd_dvdcs_arr = get_inplace_double(mbd_dvdcs_obj, "mbd.dvdcs");
+    Py_DECREF(mbd_dvdcs_obj);
+    PyArrayObject *mbd_dgdcs_arr = get_inplace_double(mbd_dgdcs_obj, "mbd.dgdcs");
+    Py_DECREF(mbd_dgdcs_obj);
+    PyArrayObject *mbd_dsdcs_arr = get_inplace_double(mbd_dsdcs_obj, "mbd.dsdcs");
+    Py_DECREF(mbd_dsdcs_obj);
 
     if (!rbd_values_arr || !rbd_dqdris_arr || !rbd_dqdeps_arr ||
         !mbd_vatoms_arr || !mbd_dbdris_arr || !mbd_dbdeps_arr ||
@@ -564,44 +583,6 @@ static PyObject *py_calc_mag_train(PyObject *self, PyObject *args, PyObject *kwa
         Py_DECREF(alpha_index_basic_arr);
         Py_DECREF(alpha_index_times_arr);
         Py_DECREF(moment_coeffs_arr);
-        Py_XDECREF(radial_basis_size_obj);
-        Py_XDECREF(rbd_values_arr);
-        Py_XDECREF(rbd_dqdris_arr);
-        Py_XDECREF(rbd_dqdeps_arr);
-        Py_XDECREF(mbd_vatoms_arr);
-        Py_XDECREF(mbd_dbdris_arr);
-        Py_XDECREF(mbd_dbdeps_arr);
-        Py_XDECREF(mbd_dvdcs_arr);
-        Py_XDECREF(mbd_dgdcs_arr);
-        Py_XDECREF(mbd_dsdcs_arr);
-        return NULL;
-    }
-
-    if (!require_inplace_double(rbd_values_arr, "rbd.values") ||
-        !require_inplace_double(rbd_dqdris_arr, "rbd.dqdris") ||
-        !require_inplace_double(rbd_dqdeps_arr, "rbd.dqdeps") ||
-        !require_inplace_double(mbd_vatoms_arr, "mbd.vatoms") ||
-        !require_inplace_double(mbd_dbdris_arr, "mbd.dbdris") ||
-        !require_inplace_double(mbd_dbdeps_arr, "mbd.dbdeps") ||
-        !require_inplace_double(mbd_dvdcs_arr, "mbd.dvdcs") ||
-        !require_inplace_double(mbd_dgdcs_arr, "mbd.dgdcs") ||
-        !require_inplace_double(mbd_dsdcs_arr, "mbd.dsdcs"))
-    {
-        Py_DECREF(radial_coeffs_arr);
-        Py_DECREF(species_coeffs_arr);
-        Py_DECREF(alpha_moment_mapping_arr);
-        Py_DECREF(alpha_index_basic_arr);
-        Py_DECREF(alpha_index_times_arr);
-        Py_DECREF(moment_coeffs_arr);
-        Py_DECREF(rbd_values_arr);
-        Py_DECREF(rbd_dqdris_arr);
-        Py_DECREF(rbd_dqdeps_arr);
-        Py_DECREF(mbd_vatoms_arr);
-        Py_DECREF(mbd_dbdris_arr);
-        Py_DECREF(mbd_dbdeps_arr);
-        Py_DECREF(mbd_dvdcs_arr);
-        Py_DECREF(mbd_dgdcs_arr);
-        Py_DECREF(mbd_dsdcs_arr);
         Py_XDECREF(radial_basis_size_obj);
         return NULL;
     }
@@ -617,15 +598,6 @@ static PyObject *py_calc_mag_train(PyObject *self, PyObject *args, PyObject *kwa
         Py_DECREF(alpha_index_basic_arr);
         Py_DECREF(alpha_index_times_arr);
         Py_DECREF(moment_coeffs_arr);
-        Py_DECREF(rbd_values_arr);
-        Py_DECREF(rbd_dqdris_arr);
-        Py_DECREF(rbd_dqdeps_arr);
-        Py_DECREF(mbd_vatoms_arr);
-        Py_DECREF(mbd_dbdris_arr);
-        Py_DECREF(mbd_dbdeps_arr);
-        Py_DECREF(mbd_dvdcs_arr);
-        Py_DECREF(mbd_dgdcs_arr);
-        Py_DECREF(mbd_dsdcs_arr);
         return NULL;
     }
 
@@ -668,15 +640,6 @@ static PyObject *py_calc_mag_train(PyObject *self, PyObject *args, PyObject *kwa
     Py_DECREF(alpha_index_basic_arr);
     Py_DECREF(alpha_index_times_arr);
     Py_DECREF(moment_coeffs_arr);
-    Py_DECREF(rbd_values_arr);
-    Py_DECREF(rbd_dqdris_arr);
-    Py_DECREF(rbd_dqdeps_arr);
-    Py_DECREF(mbd_vatoms_arr);
-    Py_DECREF(mbd_dbdris_arr);
-    Py_DECREF(mbd_dbdeps_arr);
-    Py_DECREF(mbd_dvdcs_arr);
-    Py_DECREF(mbd_dgdcs_arr);
-    Py_DECREF(mbd_dsdcs_arr);
     Py_DECREF(scaling_obj);
     Py_DECREF(min_dist_obj);
     Py_DECREF(max_dist_obj);
@@ -692,15 +655,6 @@ static PyObject *py_calc_mag_train(PyObject *self, PyObject *args, PyObject *kwa
     Py_DECREF(alpha_index_times_obj);
     Py_DECREF(alpha_index_times_count_obj);
     Py_DECREF(moment_coeffs_obj);
-    Py_DECREF(rbd_values_obj);
-    Py_DECREF(rbd_dqdris_obj);
-    Py_DECREF(rbd_dqdeps_obj);
-    Py_DECREF(mbd_vatoms_obj);
-    Py_DECREF(mbd_dbdris_obj);
-    Py_DECREF(mbd_dbdeps_obj);
-    Py_DECREF(mbd_dvdcs_obj);
-    Py_DECREF(mbd_dgdcs_obj);
-    Py_DECREF(mbd_dsdcs_obj);
     Py_DECREF(radial_coeffs_obj);
     Py_DECREF(species_coeffs_obj);
     Py_XDECREF(radial_basis_size_obj);
@@ -875,11 +829,6 @@ static PyObject *py_calc_mag_train_mgrad(PyObject *self, PyObject *args, PyObjec
     PyObject *rbd_dqdris_obj = PyObject_GetAttrString(rbd_obj, "dqdris");
     PyObject *rbd_dqdmis_obj = PyObject_GetAttrString(rbd_obj, "dqdmis");
     PyObject *rbd_dqdeps_obj = PyObject_GetAttrString(rbd_obj, "dqdeps");
-    PyArrayObject *rbd_values_arr = (PyArrayObject *)PyArray_FROM_OTF(rbd_values_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *rbd_dqdris_arr = (PyArrayObject *)PyArray_FROM_OTF(rbd_dqdris_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *rbd_dqdmis_arr = (PyArrayObject *)PyArray_FROM_OTF(rbd_dqdmis_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *rbd_dqdeps_arr = (PyArrayObject *)PyArray_FROM_OTF(rbd_dqdeps_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-
     PyObject *mbd_vatoms_obj = PyObject_GetAttrString(mbd_obj, "vatoms");
     PyObject *mbd_dbdris_obj = PyObject_GetAttrString(mbd_obj, "dbdris");
     PyObject *mbd_dbdmis_obj = PyObject_GetAttrString(mbd_obj, "dbdmis");
@@ -888,14 +837,31 @@ static PyObject *py_calc_mag_train_mgrad(PyObject *self, PyObject *args, PyObjec
     PyObject *mbd_dgdcs_obj = PyObject_GetAttrString(mbd_obj, "dgdcs");
     PyObject *mbd_dgmdcs_obj = PyObject_GetAttrString(mbd_obj, "dgmdcs");
     PyObject *mbd_dsdcs_obj = PyObject_GetAttrString(mbd_obj, "dsdcs");
-    PyArrayObject *mbd_vatoms_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_vatoms_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dbdris_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dbdris_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dbdmis_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dbdmis_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dbdeps_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dbdeps_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dvdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dvdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dgdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dgdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dgmdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dgmdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dsdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dsdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
+
+    PyArrayObject *rbd_values_arr = get_inplace_double(rbd_values_obj, "rbd.values");
+    Py_DECREF(rbd_values_obj);
+    PyArrayObject *rbd_dqdris_arr = get_inplace_double(rbd_dqdris_obj, "rbd.dqdris");
+    Py_DECREF(rbd_dqdris_obj);
+    PyArrayObject *rbd_dqdmis_arr = get_inplace_double(rbd_dqdmis_obj, "rbd.dqdmis");
+    Py_DECREF(rbd_dqdmis_obj);
+    PyArrayObject *rbd_dqdeps_arr = get_inplace_double(rbd_dqdeps_obj, "rbd.dqdeps");
+    Py_DECREF(rbd_dqdeps_obj);
+    PyArrayObject *mbd_vatoms_arr = get_inplace_double(mbd_vatoms_obj, "mbd.vatoms");
+    Py_DECREF(mbd_vatoms_obj);
+    PyArrayObject *mbd_dbdris_arr = get_inplace_double(mbd_dbdris_obj, "mbd.dbdris");
+    Py_DECREF(mbd_dbdris_obj);
+    PyArrayObject *mbd_dbdmis_arr = get_inplace_double(mbd_dbdmis_obj, "mbd.dbdmis");
+    Py_DECREF(mbd_dbdmis_obj);
+    PyArrayObject *mbd_dbdeps_arr = get_inplace_double(mbd_dbdeps_obj, "mbd.dbdeps");
+    Py_DECREF(mbd_dbdeps_obj);
+    PyArrayObject *mbd_dvdcs_arr = get_inplace_double(mbd_dvdcs_obj, "mbd.dvdcs");
+    Py_DECREF(mbd_dvdcs_obj);
+    PyArrayObject *mbd_dgdcs_arr = get_inplace_double(mbd_dgdcs_obj, "mbd.dgdcs");
+    Py_DECREF(mbd_dgdcs_obj);
+    PyArrayObject *mbd_dgmdcs_arr = get_inplace_double(mbd_dgmdcs_obj, "mbd.dgmdcs");
+    Py_DECREF(mbd_dgmdcs_obj);
+    PyArrayObject *mbd_dsdcs_arr = get_inplace_double(mbd_dsdcs_obj, "mbd.dsdcs");
+    Py_DECREF(mbd_dsdcs_obj);
 
     if (!rbd_values_arr || !rbd_dqdris_arr || !rbd_dqdmis_arr || !rbd_dqdeps_arr ||
         !mbd_vatoms_arr || !mbd_dbdris_arr || !mbd_dbdmis_arr || !mbd_dbdeps_arr ||
@@ -907,53 +873,6 @@ static PyObject *py_calc_mag_train_mgrad(PyObject *self, PyObject *args, PyObjec
         Py_DECREF(alpha_index_basic_arr);
         Py_DECREF(alpha_index_times_arr);
         Py_DECREF(moment_coeffs_arr);
-        Py_XDECREF(radial_basis_size_obj);
-        Py_XDECREF(rbd_values_arr);
-        Py_XDECREF(rbd_dqdris_arr);
-        Py_XDECREF(rbd_dqdmis_arr);
-        Py_XDECREF(rbd_dqdeps_arr);
-        Py_XDECREF(mbd_vatoms_arr);
-        Py_XDECREF(mbd_dbdris_arr);
-        Py_XDECREF(mbd_dbdmis_arr);
-        Py_XDECREF(mbd_dbdeps_arr);
-        Py_XDECREF(mbd_dvdcs_arr);
-        Py_XDECREF(mbd_dgdcs_arr);
-        Py_XDECREF(mbd_dgmdcs_arr);
-        Py_XDECREF(mbd_dsdcs_arr);
-        return NULL;
-    }
-
-    if (!require_inplace_double(rbd_values_arr, "rbd.values") ||
-        !require_inplace_double(rbd_dqdris_arr, "rbd.dqdris") ||
-        !require_inplace_double(rbd_dqdmis_arr, "rbd.dqdmis") ||
-        !require_inplace_double(rbd_dqdeps_arr, "rbd.dqdeps") ||
-        !require_inplace_double(mbd_vatoms_arr, "mbd.vatoms") ||
-        !require_inplace_double(mbd_dbdris_arr, "mbd.dbdris") ||
-        !require_inplace_double(mbd_dbdmis_arr, "mbd.dbdmis") ||
-        !require_inplace_double(mbd_dbdeps_arr, "mbd.dbdeps") ||
-        !require_inplace_double(mbd_dvdcs_arr, "mbd.dvdcs") ||
-        !require_inplace_double(mbd_dgdcs_arr, "mbd.dgdcs") ||
-        !require_inplace_double(mbd_dgmdcs_arr, "mbd.dgmdcs") ||
-        !require_inplace_double(mbd_dsdcs_arr, "mbd.dsdcs"))
-    {
-        Py_DECREF(radial_coeffs_arr);
-        Py_DECREF(species_coeffs_arr);
-        Py_DECREF(alpha_moment_mapping_arr);
-        Py_DECREF(alpha_index_basic_arr);
-        Py_DECREF(alpha_index_times_arr);
-        Py_DECREF(moment_coeffs_arr);
-        Py_DECREF(rbd_values_arr);
-        Py_DECREF(rbd_dqdris_arr);
-        Py_DECREF(rbd_dqdmis_arr);
-        Py_DECREF(rbd_dqdeps_arr);
-        Py_DECREF(mbd_vatoms_arr);
-        Py_DECREF(mbd_dbdris_arr);
-        Py_DECREF(mbd_dbdmis_arr);
-        Py_DECREF(mbd_dbdeps_arr);
-        Py_DECREF(mbd_dvdcs_arr);
-        Py_DECREF(mbd_dgdcs_arr);
-        Py_DECREF(mbd_dgmdcs_arr);
-        Py_DECREF(mbd_dsdcs_arr);
         Py_XDECREF(radial_basis_size_obj);
         return NULL;
     }
@@ -969,18 +888,6 @@ static PyObject *py_calc_mag_train_mgrad(PyObject *self, PyObject *args, PyObjec
         Py_DECREF(alpha_index_basic_arr);
         Py_DECREF(alpha_index_times_arr);
         Py_DECREF(moment_coeffs_arr);
-        Py_DECREF(rbd_values_arr);
-        Py_DECREF(rbd_dqdris_arr);
-        Py_DECREF(rbd_dqdmis_arr);
-        Py_DECREF(rbd_dqdeps_arr);
-        Py_DECREF(mbd_vatoms_arr);
-        Py_DECREF(mbd_dbdris_arr);
-        Py_DECREF(mbd_dbdmis_arr);
-        Py_DECREF(mbd_dbdeps_arr);
-        Py_DECREF(mbd_dvdcs_arr);
-        Py_DECREF(mbd_dgdcs_arr);
-        Py_DECREF(mbd_dgmdcs_arr);
-        Py_DECREF(mbd_dsdcs_arr);
         return NULL;
     }
 
@@ -1026,18 +933,6 @@ static PyObject *py_calc_mag_train_mgrad(PyObject *self, PyObject *args, PyObjec
     Py_DECREF(alpha_index_basic_arr);
     Py_DECREF(alpha_index_times_arr);
     Py_DECREF(moment_coeffs_arr);
-    Py_DECREF(rbd_values_arr);
-    Py_DECREF(rbd_dqdris_arr);
-    Py_DECREF(rbd_dqdmis_arr);
-    Py_DECREF(rbd_dqdeps_arr);
-    Py_DECREF(mbd_vatoms_arr);
-    Py_DECREF(mbd_dbdris_arr);
-    Py_DECREF(mbd_dbdmis_arr);
-    Py_DECREF(mbd_dbdeps_arr);
-    Py_DECREF(mbd_dvdcs_arr);
-    Py_DECREF(mbd_dgdcs_arr);
-    Py_DECREF(mbd_dgmdcs_arr);
-    Py_DECREF(mbd_dsdcs_arr);
     Py_DECREF(scaling_obj);
     Py_DECREF(min_dist_obj);
     Py_DECREF(max_dist_obj);
@@ -1053,18 +948,6 @@ static PyObject *py_calc_mag_train_mgrad(PyObject *self, PyObject *args, PyObjec
     Py_DECREF(alpha_index_times_obj);
     Py_DECREF(alpha_index_times_count_obj);
     Py_DECREF(moment_coeffs_obj);
-    Py_DECREF(rbd_values_obj);
-    Py_DECREF(rbd_dqdris_obj);
-    Py_DECREF(rbd_dqdmis_obj);
-    Py_DECREF(rbd_dqdeps_obj);
-    Py_DECREF(mbd_vatoms_obj);
-    Py_DECREF(mbd_dbdris_obj);
-    Py_DECREF(mbd_dbdmis_obj);
-    Py_DECREF(mbd_dbdeps_obj);
-    Py_DECREF(mbd_dvdcs_obj);
-    Py_DECREF(mbd_dgdcs_obj);
-    Py_DECREF(mbd_dgmdcs_obj);
-    Py_DECREF(mbd_dsdcs_obj);
     Py_XDECREF(radial_basis_size_obj);
 
     return (PyObject *)energies_arr;

--- a/motep/potentials/mmtp/cext/mmtp_cext_module.c
+++ b/motep/potentials/mmtp/cext/mmtp_cext_module.c
@@ -3,56 +3,7 @@
 #include <Python.h>
 #include <numpy/arrayobject.h>
 #include "mmtp_cext.h"
-
-static int require_int32(PyArrayObject *arr, const char *name)
-{
-    if (PyArray_TYPE(arr) != NPY_INT32)
-    {
-        PyErr_Format(PyExc_TypeError, "%s must be int32 array", name);
-        return 0;
-    }
-    return 1;
-}
-
-static int require_inplace_double(PyArrayObject *arr, const char *name)
-{
-    if (PyArray_TYPE(arr) != NPY_DOUBLE)
-    {
-        PyErr_Format(PyExc_TypeError, "%s must be float64 array", name);
-        return 0;
-    }
-    if (!(PyArray_FLAGS(arr) & NPY_ARRAY_WRITEABLE))
-    {
-        PyErr_Format(PyExc_ValueError, "%s must be writable", name);
-        return 0;
-    }
-    if (!(PyArray_FLAGS(arr) & NPY_ARRAY_C_CONTIGUOUS))
-    {
-        PyErr_Format(PyExc_ValueError, "%s must be C-contiguous", name);
-        return 0;
-    }
-    if (PyArray_FLAGS(arr) & NPY_ARRAY_WRITEBACKIFCOPY)
-    {
-        PyErr_Format(PyExc_ValueError, "%s must be in-place (no writeback copy)", name);
-        return 0;
-    }
-    return 1;
-}
-
-/* Cast a Python object directly to a writable, C-contiguous float64 array.
- * Returns a borrowed reference (no copy is ever made). */
-static PyArrayObject *get_inplace_double(PyObject *obj, const char *name)
-{
-    if (!PyArray_Check(obj))
-    {
-        PyErr_Format(PyExc_TypeError, "%s must be a numpy array", name);
-        return NULL;
-    }
-    PyArrayObject *arr = (PyArrayObject *)obj;
-    if (!require_inplace_double(arr, name))
-        return NULL;
-    return arr;
-}
+#include "cext_helpers.h"
 
 /* ==========================================================================
  * Python wrapper for calc_mag_run

--- a/motep/potentials/mtp/cext/cext_helpers.h
+++ b/motep/potentials/mtp/cext/cext_helpers.h
@@ -1,5 +1,6 @@
 #pragma once
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <Python.h>
 #include <numpy/arrayobject.h>
 
 static int require_int32(PyArrayObject *arr, const char *name)

--- a/motep/potentials/mtp/cext/cext_helpers.h
+++ b/motep/potentials/mtp/cext/cext_helpers.h
@@ -1,0 +1,61 @@
+#pragma once
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+
+static int require_int32(PyArrayObject *arr, const char *name)
+{
+    if (PyArray_TYPE(arr) != NPY_INT32)
+    {
+        PyErr_Format(PyExc_TypeError, "%s must be int32 array", name);
+        return 0;
+    }
+    return 1;
+}
+
+static int require_inplace_double(PyArrayObject *arr, const char *name)
+{
+    if (PyArray_TYPE(arr) != NPY_DOUBLE)
+    {
+        PyErr_Format(PyExc_TypeError, "%s must be float64 array", name);
+        return 0;
+    }
+    if (!(PyArray_FLAGS(arr) & NPY_ARRAY_WRITEABLE))
+    {
+        PyErr_Format(PyExc_ValueError, "%s must be writable", name);
+        return 0;
+    }
+    if (!(PyArray_FLAGS(arr) & NPY_ARRAY_C_CONTIGUOUS))
+    {
+        PyErr_Format(PyExc_ValueError, "%s must be C-contiguous", name);
+        return 0;
+    }
+    if (!PyArray_ISNOTSWAPPED(arr))
+    {
+        PyErr_Format(PyExc_ValueError, "%s must be native byte order", name);
+        return 0;
+    }
+    if (!(PyArray_FLAGS(arr) & NPY_ARRAY_ALIGNED))
+    {
+        PyErr_Format(PyExc_ValueError, "%s must be aligned", name);
+        return 0;
+    }
+    if (PyArray_FLAGS(arr) & NPY_ARRAY_WRITEBACKIFCOPY)
+    {
+        PyErr_Format(PyExc_ValueError, "%s must be in-place (no writeback copy)", name);
+        return 0;
+    }
+    return 1;
+}
+
+static PyArrayObject *get_inplace_double(PyObject *obj, const char *name)
+{
+    if (!PyArray_Check(obj))
+    {
+        PyErr_Format(PyExc_TypeError, "%s must be a numpy array", name);
+        return NULL;
+    }
+    PyArrayObject *arr = (PyArrayObject *)obj;
+    if (!require_inplace_double(arr, name))
+        return NULL;
+    return arr;
+}

--- a/motep/potentials/mtp/cext/mtp_cext_module.c
+++ b/motep/potentials/mtp/cext/mtp_cext_module.c
@@ -3,54 +3,7 @@
 #include <Python.h>
 #include <numpy/arrayobject.h>
 #include "mtp_cext.h"
-
-static int require_int32(PyArrayObject *arr, const char *name)
-{
-    if (PyArray_TYPE(arr) != NPY_INT32)
-    {
-        PyErr_Format(PyExc_TypeError, "%s must be int32 array", name);
-        return 0;
-    }
-    return 1;
-}
-
-static int require_inplace_double(PyArrayObject *arr, const char *name)
-{
-    if (PyArray_TYPE(arr) != NPY_DOUBLE)
-    {
-        PyErr_Format(PyExc_TypeError, "%s must be float64 array", name);
-        return 0;
-    }
-    if (!(PyArray_FLAGS(arr) & NPY_ARRAY_WRITEABLE))
-    {
-        PyErr_Format(PyExc_ValueError, "%s must be writable", name);
-        return 0;
-    }
-    if (!(PyArray_FLAGS(arr) & NPY_ARRAY_C_CONTIGUOUS))
-    {
-        PyErr_Format(PyExc_ValueError, "%s must be C-contiguous", name);
-        return 0;
-    }
-    if (PyArray_FLAGS(arr) & NPY_ARRAY_WRITEBACKIFCOPY)
-    {
-        PyErr_Format(PyExc_ValueError, "%s must be in-place (no writeback copy)", name);
-        return 0;
-    }
-    return 1;
-}
-
-static PyArrayObject *get_inplace_double(PyObject *obj, const char *name)
-{
-    if (!PyArray_Check(obj))
-    {
-        PyErr_Format(PyExc_TypeError, "%s must be a numpy array", name);
-        return NULL;
-    }
-    PyArrayObject *arr = (PyArrayObject *)obj;
-    if (!require_inplace_double(arr, name))
-        return NULL;
-    return arr;
-}
+#include "cext_helpers.h"
 
 /* ============================================================================
  * Python wrapper for calc_run

--- a/motep/potentials/mtp/cext/mtp_cext_module.c
+++ b/motep/potentials/mtp/cext/mtp_cext_module.c
@@ -39,6 +39,19 @@ static int require_inplace_double(PyArrayObject *arr, const char *name)
     return 1;
 }
 
+static PyArrayObject *get_inplace_double(PyObject *obj, const char *name)
+{
+    if (!PyArray_Check(obj))
+    {
+        PyErr_Format(PyExc_TypeError, "%s must be a numpy array", name);
+        return NULL;
+    }
+    PyArrayObject *arr = (PyArrayObject *)obj;
+    if (!require_inplace_double(arr, name))
+        return NULL;
+    return arr;
+}
+
 /* ============================================================================
  * Python wrapper for calc_run
  * Accepts mtp_data as a dict-like object and extracts parameters
@@ -161,8 +174,10 @@ static PyObject *py_calc_run(PyObject *self, PyObject *args, PyObject *kwargs)
         Py_DECREF(moment_coeffs_arr);
         return NULL;
     }
-    PyArrayObject *mbd_vatoms_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_vatoms_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    if (!mbd_vatoms_arr || !require_inplace_double(mbd_vatoms_arr, "mbd.vatoms"))
+    // PyArrayObject *mbd_vatoms_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_vatoms_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *mbd_vatoms_arr = get_inplace_double(mbd_vatoms_obj, "mbd.vatoms");
+    Py_DECREF(mbd_vatoms_obj);
+    if (!mbd_vatoms_arr)
     {
         Py_DECREF(radial_coeffs_arr);
         Py_DECREF(species_coeffs_arr);
@@ -170,8 +185,6 @@ static PyObject *py_calc_run(PyObject *self, PyObject *args, PyObject *kwargs)
         Py_DECREF(alpha_index_basic_arr);
         Py_DECREF(alpha_index_times_arr);
         Py_DECREF(moment_coeffs_arr);
-        Py_XDECREF(mbd_vatoms_arr);
-        Py_DECREF(mbd_vatoms_obj);
         return NULL;
     }
 
@@ -186,8 +199,6 @@ static PyObject *py_calc_run(PyObject *self, PyObject *args, PyObject *kwargs)
         PyErr_SetString(PyExc_MemoryError, "Failed to allocate output arrays");
         Py_XDECREF(energies_arr);
         Py_XDECREF(gradient_arr);
-        Py_DECREF(mbd_vatoms_arr);
-        Py_DECREF(mbd_vatoms_obj);
         Py_DECREF(radial_coeffs_arr);
         Py_DECREF(species_coeffs_arr);
         Py_DECREF(alpha_moment_mapping_arr);
@@ -227,8 +238,6 @@ static PyObject *py_calc_run(PyObject *self, PyObject *args, PyObject *kwargs)
     Py_DECREF(alpha_index_basic_arr);
     Py_DECREF(alpha_index_times_arr);
     Py_DECREF(moment_coeffs_arr);
-    Py_DECREF(mbd_vatoms_arr);
-    Py_DECREF(mbd_vatoms_obj);
     Py_DECREF(scaling_obj);
     Py_DECREF(min_dist_obj);
     Py_DECREF(max_dist_obj);
@@ -431,16 +440,24 @@ static PyObject *py_calc_train(PyObject *self, PyObject *args, PyObject *kwargs)
         return NULL;
     }
 
-    /* Convert to numpy arrays */
-    PyArrayObject *rbd_values_arr = (PyArrayObject *)PyArray_FROM_OTF(rbd_values_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *rbd_dqdris_arr = (PyArrayObject *)PyArray_FROM_OTF(rbd_dqdris_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *rbd_dqdeps_arr = (PyArrayObject *)PyArray_FROM_OTF(rbd_dqdeps_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_vatoms_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_vatoms_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dbdris_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dbdris_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dbdeps_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dbdeps_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dvdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dvdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dgdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dgdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *mbd_dsdcs_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_dsdcs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
+    PyArrayObject *rbd_values_arr = get_inplace_double(rbd_values_obj, "rbd.values");
+    Py_DECREF(rbd_values_obj);
+    PyArrayObject *rbd_dqdris_arr = get_inplace_double(rbd_dqdris_obj, "rbd.dqdris");
+    Py_DECREF(rbd_dqdris_obj);
+    PyArrayObject *rbd_dqdeps_arr = get_inplace_double(rbd_dqdeps_obj, "rbd.dqdeps");
+    Py_DECREF(rbd_dqdeps_obj);
+    PyArrayObject *mbd_vatoms_arr = get_inplace_double(mbd_vatoms_obj, "mbd.vatoms");
+    Py_DECREF(mbd_vatoms_obj);
+    PyArrayObject *mbd_dbdris_arr = get_inplace_double(mbd_dbdris_obj, "mbd.dbdris");
+    Py_DECREF(mbd_dbdris_obj);
+    PyArrayObject *mbd_dbdeps_arr = get_inplace_double(mbd_dbdeps_obj, "mbd.dbdeps");
+    Py_DECREF(mbd_dbdeps_obj);
+    PyArrayObject *mbd_dvdcs_arr = get_inplace_double(mbd_dvdcs_obj, "mbd.dvdcs");
+    Py_DECREF(mbd_dvdcs_obj);
+    PyArrayObject *mbd_dgdcs_arr = get_inplace_double(mbd_dgdcs_obj, "mbd.dgdcs");
+    Py_DECREF(mbd_dgdcs_obj);
+    PyArrayObject *mbd_dsdcs_arr = get_inplace_double(mbd_dsdcs_obj, "mbd.dsdcs");
+    Py_DECREF(mbd_dsdcs_obj);
 
     if (!rbd_values_arr || !rbd_dqdris_arr || !rbd_dqdeps_arr ||
         !mbd_vatoms_arr || !mbd_dbdris_arr || !mbd_dbdeps_arr ||
@@ -452,44 +469,6 @@ static PyObject *py_calc_train(PyObject *self, PyObject *args, PyObject *kwargs)
         Py_DECREF(alpha_index_basic_arr);
         Py_DECREF(alpha_index_times_arr);
         Py_DECREF(moment_coeffs_arr);
-        Py_XDECREF(rbd_values_arr);
-        Py_XDECREF(rbd_dqdris_arr);
-        Py_XDECREF(rbd_dqdeps_arr);
-        Py_XDECREF(mbd_vatoms_arr);
-        Py_XDECREF(mbd_dbdris_arr);
-        Py_XDECREF(mbd_dbdeps_arr);
-        Py_XDECREF(mbd_dvdcs_arr);
-        Py_XDECREF(mbd_dgdcs_arr);
-        Py_XDECREF(mbd_dsdcs_arr);
-        Py_DECREF(energies_arr);
-        return NULL;
-    }
-
-    if (!require_inplace_double(rbd_values_arr, "rbd.values") ||
-        !require_inplace_double(rbd_dqdris_arr, "rbd.dqdris") ||
-        !require_inplace_double(rbd_dqdeps_arr, "rbd.dqdeps") ||
-        !require_inplace_double(mbd_vatoms_arr, "mbd.vatoms") ||
-        !require_inplace_double(mbd_dbdris_arr, "mbd.dbdris") ||
-        !require_inplace_double(mbd_dbdeps_arr, "mbd.dbdeps") ||
-        !require_inplace_double(mbd_dvdcs_arr, "mbd.dvdcs") ||
-        !require_inplace_double(mbd_dgdcs_arr, "mbd.dgdcs") ||
-        !require_inplace_double(mbd_dsdcs_arr, "mbd.dsdcs"))
-    {
-        Py_DECREF(radial_coeffs_arr);
-        Py_DECREF(species_coeffs_arr);
-        Py_DECREF(alpha_moment_mapping_arr);
-        Py_DECREF(alpha_index_basic_arr);
-        Py_DECREF(alpha_index_times_arr);
-        Py_DECREF(moment_coeffs_arr);
-        Py_DECREF(rbd_values_arr);
-        Py_DECREF(rbd_dqdris_arr);
-        Py_DECREF(rbd_dqdeps_arr);
-        Py_DECREF(mbd_vatoms_arr);
-        Py_DECREF(mbd_dbdris_arr);
-        Py_DECREF(mbd_dbdeps_arr);
-        Py_DECREF(mbd_dvdcs_arr);
-        Py_DECREF(mbd_dgdcs_arr);
-        Py_DECREF(mbd_dsdcs_arr);
         Py_DECREF(energies_arr);
         return NULL;
     }
@@ -539,15 +518,6 @@ static PyObject *py_calc_train(PyObject *self, PyObject *args, PyObject *kwargs)
     Py_DECREF(alpha_index_basic_arr);
     Py_DECREF(alpha_index_times_arr);
     Py_DECREF(moment_coeffs_arr);
-    Py_DECREF(rbd_values_arr);
-    Py_DECREF(rbd_dqdris_arr);
-    Py_DECREF(rbd_dqdeps_arr);
-    Py_DECREF(mbd_vatoms_arr);
-    Py_DECREF(mbd_dbdris_arr);
-    Py_DECREF(mbd_dbdeps_arr);
-    Py_DECREF(mbd_dvdcs_arr);
-    Py_DECREF(mbd_dgdcs_arr);
-    Py_DECREF(mbd_dsdcs_arr);
     Py_DECREF(scaling_obj);
     Py_DECREF(min_dist_obj);
     Py_DECREF(max_dist_obj);
@@ -561,15 +531,6 @@ static PyObject *py_calc_train(PyObject *self, PyObject *args, PyObject *kwargs)
     Py_DECREF(alpha_index_times_count_obj);
     Py_DECREF(moment_coeffs_obj);
     Py_DECREF(alpha_scalar_moments_obj);
-    Py_DECREF(rbd_values_obj);
-    Py_DECREF(rbd_dqdris_obj);
-    Py_DECREF(rbd_dqdeps_obj);
-    Py_DECREF(mbd_vatoms_obj);
-    Py_DECREF(mbd_dbdris_obj);
-    Py_DECREF(mbd_dbdeps_obj);
-    Py_DECREF(mbd_dvdcs_obj);
-    Py_DECREF(mbd_dgdcs_obj);
-    Py_DECREF(mbd_dsdcs_obj);
 
     return (PyObject *)energies_arr;
 }

--- a/motep/potentials/mtp/cext/mtp_cext_module.c
+++ b/motep/potentials/mtp/cext/mtp_cext_module.c
@@ -127,7 +127,6 @@ static PyObject *py_calc_run(PyObject *self, PyObject *args, PyObject *kwargs)
         Py_DECREF(moment_coeffs_arr);
         return NULL;
     }
-    // PyArrayObject *mbd_vatoms_arr = (PyArrayObject *)PyArray_FROM_OTF(mbd_vatoms_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *mbd_vatoms_arr = get_inplace_double(mbd_vatoms_obj, "mbd.vatoms");
     Py_DECREF(mbd_vatoms_obj);
     if (!mbd_vatoms_arr)


### PR DESCRIPTION
Introduce a function to handle the NumPy arrays that should be in-place modified. This more explicitly disallows copies based on non-contigous arrays or with the wrong data type.