### PR TITLE
Log a warning if a nearest neighbor is closer than `radial_basis.min`

### DIFF
--- a/motep/potentials/mtp/base.py
+++ b/motep/potentials/mtp/base.py
@@ -1,3 +1,4 @@
+import logging
 from abc import abstractmethod
 from dataclasses import dataclass, field
 from typing import ClassVar
@@ -8,6 +9,22 @@ from ase import Atoms
 from ase.neighborlist import PrimitiveNeighborList
 
 from motep.potentials.mtp.data import MTPData
+
+logger = logging.getLogger(__name__)
+
+
+def _warn_if_neighbors_below_min_dist(
+    neighbor_vectors: npt.NDArray[np.float64],
+    min_dist: float,
+) -> None:
+    distances = np.linalg.norm(neighbor_vectors, axis=-1)
+    min_distance = np.min(distances)
+    if min_distance < min_dist:
+        logger.warning(
+            "Nearest-neighbor distance (%s A) is smaller than min_dist (%s A).",
+            f"{min_distance:.6f}",
+            f"{min_dist:.6f}",
+        )
 
 
 class ModeBase:
@@ -216,6 +233,13 @@ class EngineWithNeighborlist(ModeBase):
         interatomic_vectors += offsets  # account for periodic images
         interatomic_vectors -= positions[:, None, :]  # r_i
         interatomic_vectors[self._neighbors[:, :] < 0, :] = max_dist
+        valid_neighbors = self._neighbors >= 0
+        neighbor_vectors = interatomic_vectors[valid_neighbors]
+        if neighbor_vectors.size:
+            _warn_if_neighbors_below_min_dist(
+                neighbor_vectors,
+                self.mtp_data.radial_basis.min,
+            )
         return interatomic_vectors
 
     def _get_neighbors_and_offsets(self, atoms: Atoms) -> tuple[np.ndarray, np.ndarray]:

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1,5 +1,6 @@
 """Tests for the ASE calculator."""
 
+import logging
 import pathlib
 import shutil
 
@@ -83,3 +84,23 @@ def test_min_dist(data_path: pathlib.Path, tmp_path: pathlib.Path) -> None:
 
     np.testing.assert_allclose(energy, energy_ref)
     np.testing.assert_allclose(forces, forces_ref, rtol=0.0, atol=1e-6)
+
+
+def test_warning_if_neighbors_are_below_min_dist(
+    data_path: pathlib.Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Log a warning if a nearest-neighbor distance is smaller than `min_dist`."""
+    path = data_path / "fitting/molecules/291/10"
+
+    atoms = read_cfg(path / "out.cfg", index=0)
+    energy_ref = atoms.get_potential_energy()
+
+    mtp_data = read_mtp(path / "pot.mtp")
+    mtp_data.radial_basis.min = 1.5
+    atoms.calc = MTP(mtp_data)
+    with caplog.at_level(logging.WARNING):
+        energy = atoms.get_potential_energy()
+
+    assert "smaller than min_dist" in caplog.text
+    assert not np.isclose(energy, energy_ref)


### PR DESCRIPTION
This PR adds a check for `radial_basis.min`; if a nearest neighbor distance is smaller than `radial_basis.min`, the calculator will give a log with `logger.warning`.