### PR TITLE
Fix MTP parameter order in written .mtp files

### DIFF
--- a/motep/io/mlip/mtp.py
+++ b/motep/io/mlip/mtp.py
@@ -227,7 +227,7 @@ def write_mtp(
     file: os.PathLike,
     data: MTPData | MagMTPData,
     *,
-    legacy: bool = False,
+    legacy: bool = True,
 ) -> None:
     """Write an MLIP .mtp file.
 

--- a/motep/io/mlip/mtp.py
+++ b/motep/io/mlip/mtp.py
@@ -168,6 +168,19 @@ def _format_list(value: list) -> str:
     return "{" + ", ".join(f"{_format_value(_)}" for _ in value) + "}"
 
 
+def _write_basis_sections(fd: TextIO, data_dict: dict) -> None:
+    for basis_key, type_key in [
+        ("radial_basis", "radial_basis_type"),
+        ("magnetic_basis", "magnetic_basis_type"),
+    ]:
+        basis = data_dict.get(basis_key, {})
+        if basis:
+            fd.write(f"{type_key} = {basis['type']}\n")
+            fd.write(f"\tmin = {_format_value(basis['min'])}\n")
+            fd.write(f"\tmax = {_format_value(basis['max'])}\n")
+            fd.write(f"\tsize = {_format_value(basis['size'])}\n")
+
+
 def _write_mtp_file(file: os.PathLike, data_dict: dict) -> None:
     """Write a raw data dict to an MLIP .mtp file."""
     keys0 = [
@@ -178,7 +191,6 @@ def _write_mtp_file(file: os.PathLike, data_dict: dict) -> None:
         "potential_tag",
     ]
     keys2 = [
-        "radial_funcs_count",
         "alpha_moments_count",
         "alpha_index_basic_count",
         "alpha_index_basic",
@@ -195,16 +207,10 @@ def _write_mtp_file(file: os.PathLike, data_dict: dict) -> None:
         for key in keys0:
             if data_dict.get(key) is not None:
                 fd.write(f"{key} = {_format_value(data_dict[key])}\n")
-        for basis_key, type_key in [
-            ("radial_basis", "radial_basis_type"),
-            ("magnetic_basis", "magnetic_basis_type"),
-        ]:
-            basis = data_dict.get(basis_key, {})
-            if basis:
-                fd.write(f"{type_key} = {basis['type']}\n")
-                fd.write(f"\tmin = {_format_value(basis['min'])}\n")
-                fd.write(f"\tmax = {_format_value(basis['max'])}\n")
-                fd.write(f"\tsize = {_format_value(basis['size'])}\n")
+        _write_basis_sections(fd, data_dict)
+        if data_dict.get("radial_funcs_count") is not None:
+            rfc = _format_value(data_dict["radial_funcs_count"])
+            fd.write(f"radial_funcs_count = {rfc}\n")
         if data_dict.get("radial_coeffs") is not None:
             fd.write("\tradial_coeffs\n")
             for k0, k1 in itertools.product(range(species_count), repeat=2):

--- a/tests/io/test_mtp.py
+++ b/tests/io/test_mtp.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 from motep.io.mlip.mtp import read_mtp, write_mtp
+from motep.potentials.mtp.data import BasisData, MTPData
 
 
 def test_mtp(data_path: pathlib.Path, tmp_path: pathlib.Path) -> None:
@@ -21,6 +22,33 @@ def test_mtp(data_path: pathlib.Path, tmp_path: pathlib.Path) -> None:
 
     for key, value in d_ref.items():
         if isinstance(value, np.ndarray):
+            np.testing.assert_array_equal(d[key], value)
+        else:
+            assert d[key] == value
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+def test_mtp_roundtrip_initialized(legacy: bool, tmp_path: pathlib.Path) -> None:
+    """Roundtrip write/read test with initialized (non-None) radial_coeffs."""
+    data = MTPData(
+        version="1.1.0",
+        species_count=2,
+        radial_funcs_count=4,
+        radial_basis=BasisData(type="RBChebyshev", min=2.0, max=5.0, size=8),
+        alpha_scalar_moments=3,
+    )
+    data.initialize(np.random.default_rng(0))
+
+    write_mtp(tmp_path / "test.mtp", data, legacy=legacy)
+    d = read_mtp(tmp_path / "test.mtp")
+
+    d_ref = asdict(data)
+    d = asdict(d)
+
+    for key, value in d_ref.items():
+        if isinstance(value, np.ndarray) and np.issubdtype(value.dtype, np.floating):
+            np.testing.assert_allclose(d[key], value, rtol=1e-14)
+        elif isinstance(value, np.ndarray):
             np.testing.assert_array_equal(d[key], value)
         else:
             assert d[key] == value


### PR DESCRIPTION
Adjust/fix the order of parameters in the written .mtp files. Refactor writing basis sections. Add roundtrip IO tests to validate writing initialized MTPs.

Previously ``radial_funcs_count`` was written too late which should in most cases have broken reading again.

Edit: Now the old MTP writer is used by default for non-magnetic MTPs, to keep compatibility.