### PR TITLE
Fix evaluator for magnetic moments

### DIFF
--- a/motep/evaluate/evaluator.py
+++ b/motep/evaluate/evaluator.py
@@ -69,6 +69,11 @@ class Evaluator:
                 relax_magmoms=self.relax_magmoms,
             )
             atoms.calc.targets = targets
+
+            # Special handling of magmoms, since they can be both results and input
+            if "magmoms" in targets:
+                atoms.set_initial_magnetic_moments(targets["magmoms"])
+
             energy = atoms.get_potential_energy()
             logger.info("configuration %d: %s", i, energy)
 

--- a/motep/evaluate/evaluator.py
+++ b/motep/evaluate/evaluator.py
@@ -82,8 +82,7 @@ class Evaluator:
                 atoms.set_initial_magnetic_moments(targets["magmoms"])
 
             energy = atoms.get_potential_energy()
-            if self.comm.rank == 0:
-                logger.info("configuration %d: %s", i, energy)
+            logger.info("configuration %d: %s", i, energy)
 
         return images_eval
 

--- a/motep/evaluate/evaluator.py
+++ b/motep/evaluate/evaluator.py
@@ -5,12 +5,14 @@ from copy import copy
 from pathlib import Path
 from pprint import pformat
 
+from ase import Atoms
+
 import motep.io
 from motep.calculator import make_calculator
 from motep.io.mlip.mtp import read_mtp
 from motep.io.utils import get_dummy_species, read_images
 from motep.loss import ErrorPrinter
-from motep.parallel import DummyMPIComm
+from motep.parallel import DummyMPIComm, world
 from motep.potentials.mtp.data import MTPData
 
 from .setting import load_setting_evaluate
@@ -25,7 +27,9 @@ class Evaluator:
         self,
         mtp_data: MTPData,
         engine: str = "cext",
+        *,
         relax_magmoms: bool | None = None,
+        comm: DummyMPIComm = world,
     ) -> None:
         """Initialize Evaluator.
 
@@ -37,13 +41,16 @@ class Evaluator:
             Engine to use for calculations ("numpy", "numba", "jax", "cext", etc.).
         relax_magmoms : bool or None
             Whether to relax magnetic moments.  ``None`` uses mode-based default.
+        comm : MPI.Comm
+            MPI communicator.
 
         """
         self.mtp_data = mtp_data
         self.engine = engine
         self.relax_magmoms = relax_magmoms
+        self.comm = comm
 
-    def evaluate(self, images: list) -> list:
+    def evaluate(self, images: list[Atoms]) -> list[Atoms]:
         """Run MTP calculations on images.
 
         Parameters
@@ -75,7 +82,8 @@ class Evaluator:
                 atoms.set_initial_magnetic_moments(targets["magmoms"])
 
             energy = atoms.get_potential_energy()
-            logger.info("configuration %d: %s", i, energy)
+            if self.comm.rank == 0:
+                logger.info("configuration %d: %s", i, energy)
 
         return images_eval
 
@@ -118,6 +126,7 @@ def evaluate_from_setting(filename_setting: str, comm: DummyMPIComm) -> None:
         mtp_data,
         engine=setting.common.engine,
         relax_magmoms=setting.common.relax_magmoms,
+        comm=comm,
     )
     images_final = evaluator.evaluate(images_initial)
 

--- a/motep/grade/grader.py
+++ b/motep/grade/grader.py
@@ -172,8 +172,7 @@ class Grader:
             # evaluate `MV_grade` for each configuration
             for i, (atoms, maxvol_grade) in enumerate(zip(images, grades, strict=True)):
                 atoms.calc.results["MV_grade"] = maxvol_grade
-                if self.comm.rank == 0:
-                    logger.info("configuration %d: %s", i, maxvol_grade)
+                logger.info("configuration %d: %s", i, maxvol_grade)
             return images
         if self.mode == GradeMode.NEIGHBORHOOD:
             idx = 0
@@ -182,8 +181,7 @@ class Grader:
                 maxvol_grade = grades_per_image.max()
                 atoms.calc.results["nbh_grades"] = grades_per_image
                 atoms.calc.results["MV_grade"] = maxvol_grade
-                if self.comm.rank == 0:
-                    logger.info("configuration %d: %s", i, maxvol_grade)
+                logger.info("configuration %d: %s", i, maxvol_grade)
                 idx += len(atoms)
             return images
         raise ValueError(self.mode)

--- a/motep/grade/grader.py
+++ b/motep/grade/grader.py
@@ -172,7 +172,8 @@ class Grader:
             # evaluate `MV_grade` for each configuration
             for i, (atoms, maxvol_grade) in enumerate(zip(images, grades, strict=True)):
                 atoms.calc.results["MV_grade"] = maxvol_grade
-                logger.info("configuration %d: %s", i, maxvol_grade)
+                if self.comm.rank == 0:
+                    logger.info("configuration %d: %s", i, maxvol_grade)
             return images
         if self.mode == GradeMode.NEIGHBORHOOD:
             idx = 0
@@ -181,7 +182,8 @@ class Grader:
                 maxvol_grade = grades_per_image.max()
                 atoms.calc.results["nbh_grades"] = grades_per_image
                 atoms.calc.results["MV_grade"] = maxvol_grade
-                logger.info("configuration %d: %s", i, maxvol_grade)
+                if self.comm.rank == 0:
+                    logger.info("configuration %d: %s", i, maxvol_grade)
                 idx += len(atoms)
             return images
         raise ValueError(self.mode)


### PR DESCRIPTION
This pull request fixes the handling of magnetic moments in Evaluator. In addition, it also improves parallel logging and annotation.

* Added logic to set initial magnetic moments when `"magmoms"` are present in calculation targets. Previously they were not initialized and thereby set to zeros, which mostly brings the relaxed magnetic moments to different local minima.
* The `Evaluator` class now accepts a `comm` (MPI communicator) argument, defaulting to `world`, enabling parallel execution and communication.
* Logging statements in both the evaluator and grader are now executed only on the root process (`comm.rank == 0`).