### PR TITLE
Update ruff linter configuration to ignore DOC201 rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,4 +73,4 @@ local_scheme = "no-local-version"
 [tool.ruff.lint]
 preview = true  # necessary to activate many pycodestyle rules
 select = ["ALL"]
-ignore = ["CPY001"]
+ignore = ["CPY001", "DOC201"]


### PR DESCRIPTION
The DOC201 rule is triggered by missing return sections in docstrings. This is also the case for private "_..." methods.
The suggested solution here is to ignore the DOC201 rule.