### PR TITLE
Limit workflow triggers to main branch and pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,12 +2,12 @@ name: Build sdist and wheels
 on:
   push:
     branches:
-      - "*"
+      - main
     tags:
       - "*"
   pull_request:
     branches:
-      - "*"
+      - main
 jobs:
   build_sdist:
     name: Build sdist

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,13 +2,15 @@ name: Docs
 on:
   push:
     branches:
-      - "*"
+      - main
     paths:
       - "docs/**"
       - "examples/**"
       - ".github/workflows/docs.yml"
       - "pyproject.toml"
   pull_request:
+    branches:
+      - main
     paths:
       - "docs/**"
       - "examples/**"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,10 +2,10 @@ name: Tests
 on:
   push:
     branches:
-      - "*"
+      - main
   pull_request:
     branches:
-      - "*"
+      - main
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR suggests to limit workflows to only trigger for main and PRs to the main branch. Tags are left to always trigger, since they are so far always used for release.