### PR TITLE
Refactor update methods to return a boolean indicating coefficient changes and add caching logic to prevent unnecessary recalculations in MTP parameters.

### DIFF
--- a/motep/calculator.py
+++ b/motep/calculator.py
@@ -117,8 +117,8 @@ class MTP(Calculator):
 
     def update_parameters(self, mtp_data: MTPData) -> None:
         """Update MTP parameters."""
-        self.engine.update(mtp_data)
-        self.results = {}  # trigger new calculation
+        if self.engine.update(mtp_data):
+            self.results = {}
 
     def calculate(
         self,
@@ -193,8 +193,8 @@ class MMTP(MTP):
         self._relaxed_magmoms: np.ndarray | None = None
 
     def update_parameters(self, mtp_data: MagMTPData) -> None:
-        self.engine.update(mtp_data)
-        self.results = {}  # trigger new calculation
+        if self.engine.update(mtp_data):
+            self.results = {}
 
     def reset(self) -> None:
         """Clear all information from old calculation."""

--- a/motep/potentials/mmtp/base.py
+++ b/motep/potentials/mmtp/base.py
@@ -160,6 +160,7 @@ class MagEngineBase(MagModeBase, EngineBase):
             I. Novikov, Blazej Grabowski, Fritz Körmann and A. V. Shapeev, npj Comput. Mater. 8, 13 (2022).
 
         """
+        self._last_coeffs: tuple | None = None
         self.update(MagMTPData.from_base(mtp_data))
         self.results = {}
         self.neighbor_list = None
@@ -171,11 +172,17 @@ class MagEngineBase(MagModeBase, EngineBase):
         # used for `Level2MTPOptimizer`
         self.rbd = MagRadialBasisData(mode=mode)
 
-    def update(self, mtp_data: MagMTPData) -> None:
-        """Update MTP parameters."""
+    def update(self, mtp_data: MagMTPData) -> bool:
+        """Update MTP parameters.
+
+        Returns
+        -------
+        bool
+            Whether the coefficients changed since the previous update.
+
+        """
         self.mtp_data: MagMTPData = mtp_data
-        if self.mtp_data.species.size == 0:
-            self.mtp_data.species = list(range(self.mtp_data.species_count))
+        return super().update(mtp_data)
 
     def calculate(
         self, atoms: Atoms, magmoms: npt.NDArray[np.float64] | None = None

--- a/motep/potentials/mmtp/base.py
+++ b/motep/potentials/mmtp/base.py
@@ -160,7 +160,7 @@ class MagEngineBase(MagModeBase, EngineBase):
             I. Novikov, Blazej Grabowski, Fritz Körmann and A. V. Shapeev, npj Comput. Mater. 8, 13 (2022).
 
         """
-        self._last_coeffs: tuple | None = None
+        self._last_state: tuple | None = None
         self.update(MagMTPData.from_base(mtp_data))
         self.results = {}
         self.neighbor_list = None

--- a/motep/potentials/mmtp/data.py
+++ b/motep/potentials/mmtp/data.py
@@ -32,6 +32,17 @@ class MagMTPData(MTPData):
         )
     )
 
+    def basis_state(self) -> tuple:
+        """Extend the base snapshot with the magnetic-basis descriptor."""
+        mb = self.magnetic_basis
+        return (
+            *super().basis_state(),
+            mb.type,
+            float(mb.min),
+            float(mb.max),
+            int(mb.size),
+        )
+
     @classmethod
     def from_base(cls, obj: MTPData) -> Self:
         """Convert base class instance to MagMTPData.

--- a/motep/potentials/mtp/base.py
+++ b/motep/potentials/mtp/base.py
@@ -285,7 +285,7 @@ class EngineBase(EngineWithNeighborlist):
             training; `'run'` is the default mode suitable for MD.
 
         """
-        self._last_coeffs: tuple | None = None
+        self._last_state: tuple | None = None
         self.update(mtp_data)
         self.results = {}
         self.neighbor_list = None
@@ -303,42 +303,18 @@ class EngineBase(EngineWithNeighborlist):
         Returns
         -------
         bool
-            Whether the coefficients changed since the previous update.
+            Whether any input that determines the computed energy/forces
+            changed since the previous update (see
+            :meth:`MTPData.basis_state`). When ``False``, the cached results may
+            be reused without recomputing the basis.
 
         """
         self.mtp_data = mtp_data
         if self.mtp_data.species.size == 0:
             self.mtp_data.species = list(range(self.mtp_data.species_count))
-        return self._mark_params(mtp_data)
-
-    @staticmethod
-    def _coeffs_equal(a: tuple | None, b: tuple | None) -> bool:
-        """Element-wise equality of two coefficient snapshots."""
-        if a is None or b is None:
-            return False
-        for x, y in zip(a, b, strict=True):
-            if x is None or y is None:
-                if x is not y:  # exactly one is None
-                    return False
-                continue
-            if not np.array_equal(x, y):
-                return False
-        return True
-
-    def _mark_params(self, mtp_data: MTPData) -> bool:
-        """Record the coefficient state and report whether it changed."""
-
-        def _copy(x: np.ndarray | None) -> np.ndarray | None:
-            return None if x is None else np.array(x, dtype=float)
-
-        snapshot = (
-            float(mtp_data.scaling),
-            _copy(mtp_data.moment_coeffs),
-            _copy(mtp_data.species_coeffs),
-            _copy(mtp_data.radial_coeffs),
-        )
-        changed = not self._coeffs_equal(snapshot, self._last_coeffs)
-        self._last_coeffs = snapshot
+        state = mtp_data.basis_state()
+        changed = not mtp_data.basis_state_equal(state, self._last_state)
+        self._last_state = state
         return changed
 
     def check_species(self, atoms: Atoms) -> None:

--- a/motep/potentials/mtp/base.py
+++ b/motep/potentials/mtp/base.py
@@ -285,6 +285,7 @@ class EngineBase(EngineWithNeighborlist):
             training; `'run'` is the default mode suitable for MD.
 
         """
+        self._last_coeffs: tuple | None = None
         self.update(mtp_data)
         self.results = {}
         self.neighbor_list = None
@@ -296,11 +297,49 @@ class EngineBase(EngineWithNeighborlist):
         # used for `Level2MTPOptimizer`
         self.rbd = RadialBasisData(mode=mode)
 
-    def update(self, mtp_data: MTPData) -> None:
-        """Update MTP parameters."""
+    def update(self, mtp_data: MTPData) -> bool:
+        """Update MTP parameters.
+
+        Returns
+        -------
+        bool
+            Whether the coefficients changed since the previous update.
+
+        """
         self.mtp_data = mtp_data
         if self.mtp_data.species.size == 0:
             self.mtp_data.species = list(range(self.mtp_data.species_count))
+        return self._mark_params(mtp_data)
+
+    @staticmethod
+    def _coeffs_equal(a: tuple | None, b: tuple | None) -> bool:
+        """Element-wise equality of two coefficient snapshots."""
+        if a is None or b is None:
+            return False
+        for x, y in zip(a, b, strict=True):
+            if x is None or y is None:
+                if x is not y:  # exactly one is None
+                    return False
+                continue
+            if not np.array_equal(x, y):
+                return False
+        return True
+
+    def _mark_params(self, mtp_data: MTPData) -> bool:
+        """Record the coefficient state and report whether it changed."""
+
+        def _copy(x: np.ndarray | None) -> np.ndarray | None:
+            return None if x is None else np.array(x, dtype=float)
+
+        snapshot = (
+            float(mtp_data.scaling),
+            _copy(mtp_data.moment_coeffs),
+            _copy(mtp_data.species_coeffs),
+            _copy(mtp_data.radial_coeffs),
+        )
+        changed = not self._coeffs_equal(snapshot, self._last_coeffs)
+        self._last_coeffs = snapshot
+        return changed
 
     def check_species(self, atoms: Atoms) -> None:
         """Check if `atoms` comply with the `mtp_data.species`.

--- a/motep/potentials/mtp/data.py
+++ b/motep/potentials/mtp/data.py
@@ -3,6 +3,7 @@
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass, field, replace
+from itertools import starmap
 from numbers import Integral
 
 import numpy as np
@@ -25,6 +26,17 @@ def get_types(
     """
     species = list(species)
     return np.fromiter((species.index(_) for _ in atoms.numbers), dtype=np.int32)
+
+
+def _copy_array(x: npt.NDArray | None) -> npt.NDArray | None:
+    return None if x is None else np.array(x)
+
+
+def _fields_equal(x: object, y: object) -> bool:
+    """Value equality that tolerates ``None`` and array-valued fields."""
+    if x is None or y is None:
+        return x is y
+    return bool(np.array_equal(x, y))
 
 
 def _default_factory_int() -> npt.NDArray[np.int32]:
@@ -115,6 +127,34 @@ class MTPData:
             rfc = self.radial_funcs_count
             rbs = self.radial_basis.size
             self.radial_coeffs = rng.uniform(-0.1, +0.1, (spc, spc, rfc, rbs))
+
+    def basis_state(self) -> tuple:
+        """Snapshot of every input that determines the computed energy/forces.
+
+        Used to decide whether cached basis data can be reused after an
+        :meth:`update`. Cosmetic/bookkeeping fields (``version``,
+        ``potential_name``, ``optimized``) are excluded, as are the
+        structure-defining index arrays (``alpha_*``) since they affect shape.
+        """
+        rb = self.radial_basis
+        return (
+            float(self.scaling),
+            _copy_array(self.radial_coeffs),
+            _copy_array(self.moment_coeffs),
+            _copy_array(self.species_coeffs),
+            _copy_array(self.species),
+            rb.type,
+            float(rb.min),
+            float(rb.max),
+            int(rb.size),
+        )
+
+    @staticmethod
+    def basis_state_equal(a: tuple | None, b: tuple | None) -> bool:
+        """Whether two :meth:`basis_state` snapshots are equal."""
+        if a is None or b is None:
+            return False
+        return len(a) == len(b) and all(starmap(_fields_equal, zip(a, b, strict=True)))
 
     @property
     def species(self) -> npt.NDArray[np.int32]:

--- a/motep/potentials/mtp/jax/engine.py
+++ b/motep/potentials/mtp/jax/engine.py
@@ -26,7 +26,7 @@ class JaxMTPEngine(EngineBase):
         self.basis_converter = None
         super().__init__(*args, **kwargs)
 
-    def update(self, mtp_data: MTPData) -> None:
+    def update(self, mtp_data: MTPData) -> bool:
         """Update MTP parameters.
 
         Raises
@@ -34,7 +34,7 @@ class JaxMTPEngine(EngineBase):
         ValueError: If `level` is updated after initialization.
 
         """
-        super().update(mtp_data)
+        changed = super().update(mtp_data)
         if self.mtp_data.alpha_moments_count is not None:
             level = moments_count_to_level_map[mtp_data.alpha_moments_count]
             if self.moment_basis is None:
@@ -45,6 +45,7 @@ class JaxMTPEngine(EngineBase):
                 msg = "Changing level is not allowed, use a new instance instead."
                 raise ValueError(msg)
             self.basis_converter.remap_mlip_moment_coeffs(self.mtp_data)
+        return changed
 
     def _calculate(self, atoms: Atoms) -> tuple:
         mtp_data = self.mtp_data

--- a/motep/potentials/mtp/numpy/engine.py
+++ b/motep/potentials/mtp/numpy/engine.py
@@ -24,11 +24,12 @@ class NumpyMTPEngine(EngineBase):
         super().__init__(mtp_data, **{**kwargs, "mode": "train"})
         self.mode = kwargs.get("mode", "run")
 
-    def update(self, mtp_data: MTPData) -> None:
+    def update(self, mtp_data: MTPData) -> bool:
         """Update MTP parameters."""
-        super().update(mtp_data)
+        changed = super().update(mtp_data)
         if self.mtp_data.radial_coeffs is not None:
             self.rb.update_coeffs(self.mtp_data.radial_coeffs)
+        return changed
 
     def _calc_basis(
         self,

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -86,6 +86,50 @@ def test_min_dist(data_path: pathlib.Path, tmp_path: pathlib.Path) -> None:
     np.testing.assert_allclose(forces, forces_ref, rtol=0.0, atol=1e-6)
 
 
+class _CalcCounter:
+    """Wrap ``engine._calculate`` to count how often the basis is rebuilt."""
+
+    def __init__(self, engine: object) -> None:
+        self.n = 0
+        self._orig = engine._calculate
+        engine._calculate = self._wrapped
+
+    def _wrapped(self, *args: object, **kwargs: object) -> object:
+        self.n += 1
+        return self._orig(*args, **kwargs)
+
+
+def test_guard_skips_recompute_when_coefficients_unchanged(
+    data_path: pathlib.Path,
+) -> None:
+    """Re-setting identical coefficients must not rebuild the basis."""
+    path = data_path / "fitting/molecules/291/10"
+    mtp_data = read_mtp(path / "pot.mtp")
+    atoms = read_cfg(path / "out.cfg", index=0)
+    atoms.calc = MTP(mtp_data, engine="numpy")
+    counter = _CalcCounter(atoms.calc.engine)
+
+    energy = atoms.get_potential_energy()
+    assert counter.n == 1
+
+    # Same coefficients, same geometry -> cached, no rebuild.
+    atoms.calc.update_parameters(mtp_data)
+    assert atoms.get_potential_energy() == energy
+    assert counter.n == 1
+
+    # Changing only `optimized` keeps the coefficients -> still cached.
+    mtp_data.optimized = ["moment_coeffs"]
+    atoms.calc.update_parameters(mtp_data)
+    assert atoms.get_potential_energy() == energy
+    assert counter.n == 1
+
+    # Changing a coefficient must rebuild and change the result.
+    mtp_data.moment_coeffs += mtp_data.moment_coeffs + 0.1
+    atoms.calc.update_parameters(mtp_data)
+    assert atoms.get_potential_energy() != energy
+    assert counter.n == 2
+
+
 def test_warning_if_neighbors_are_below_min_dist(
     data_path: pathlib.Path,
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -130,6 +130,24 @@ def test_guard_skips_recompute_when_coefficients_unchanged(
     assert counter.n == 2
 
 
+def test_guard_recomputes_on_radial_basis_change(data_path: pathlib.Path) -> None:
+    """Changing the radial basis (read live) must invalidate the cache."""
+    path = data_path / "fitting/molecules/291/10"
+    mtp_data = read_mtp(path / "pot.mtp")
+    atoms = read_cfg(path / "out.cfg", index=0)
+    atoms.calc = MTP(mtp_data, engine="numpy")
+    counter = _CalcCounter(atoms.calc.engine)
+
+    energy = atoms.get_potential_energy()
+    assert counter.n == 1
+
+    # Same coefficients but a different cutoff -> must rebuild and change.
+    mtp_data.radial_basis.max = mtp_data.radial_basis.max - 0.3
+    atoms.calc.update_parameters(mtp_data)
+    assert atoms.get_potential_energy() != energy
+    assert counter.n == 2
+
+
 def test_warning_if_neighbors_are_below_min_dist(
     data_path: pathlib.Path,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
This PR adds a cache in the MTP calculator for parameters, so that calls after an update with unchanged parameters do not unneccessarily trigger a recompute. `Atoms` properties like positions are already checked through ASE.