### PR TITLE
Two fixes

### DIFF
--- a/motep/loss.py
+++ b/motep/loss.py
@@ -248,9 +248,9 @@ class LossFunctionStress:
         )
 
         self.volumes = np.fromiter(
-            (images[i].cell.volume for i in self.idcs_str),
+            (atoms.cell.volume for atoms in images),
             dtype=float,
-            count=self.idcs_str.size,
+            count=len(images),
         )
 
         numbers_of_atoms = np.fromiter(

--- a/motep/optimizers/base.py
+++ b/motep/optimizers/base.py
@@ -145,7 +145,7 @@ class ParallelOptimizerBase(OptimizerBase):
             op = self.loss.comm.bcast(None, root=0)
             if op == self._OP_STOP:
                 break
-            elif op == self._OP_LOSS:
+            if op == self._OP_LOSS:
                 self.loss(None)
             elif op == self._OP_JAC:
                 self.loss.jac(None)
@@ -165,8 +165,7 @@ class ParallelOptimizerBase(OptimizerBase):
         else:
             self._worker_loop()
             result_x = None
-        result_x = self.loss.comm.bcast(result_x, root=0)
-        self.loss.mtp_data.parameters = result_x
+        self.loss(result_x)  # also broadcasts optimized parameters to all ranks
 
     @abstractmethod
     def _optimize(self, **kwargs: dict[str, Any]) -> npt.NDArray[np.float64]:

--- a/motep/optimizers/scipy.py
+++ b/motep/optimizers/scipy.py
@@ -140,4 +140,6 @@ class ScipyMinimizeOptimizer(ScipyOptimizerBase):
             **kwargs,
         )
         self.print_result(result)
+        if not result.success:
+            self.rank0_loss(result.x)
         return result.x

--- a/motep/optimizers/scipy.py
+++ b/motep/optimizers/scipy.py
@@ -140,6 +140,4 @@ class ScipyMinimizeOptimizer(ScipyOptimizerBase):
             **kwargs,
         )
         self.print_result(result)
-        if not result.success:
-            self.rank0_loss(result.x)
         return result.x


### PR DESCRIPTION
This PR fixes two smaller bugs.

1. If the Scipy minimize optimizer fails, it might leave a stale loss state from optimization trials, while the latest "result" that is actually returned might still be usefull. At failiure, the loss is therefore recomputed with the returned parameters.

2. In the stress loss function part, the volumes have been computed for `self.idcs_str`. However, they are later refered as `self.volumes[i]`, where `i` runs over all indices. (`if i not in self.idcs_str: continue` skipps non–stress containing indices.) The fix is to make a list of all volumes.

Edit: Make 1. rely on #125 and always call loss in ParallelOptimizerBase.optimize, so that this fixes all optimizers. #125 still avoids recalculation when not needed.