### PR TITLE
Split the engine.calculate() method into efs() and jac() to flexibly enable separate evaluations

### DIFF
--- a/benchmarks/engines.py
+++ b/benchmarks/engines.py
@@ -9,7 +9,7 @@ import numba as nb
 import numpy as np
 from ase import Atoms
 
-from motep.calculator import MTP
+from motep.calculator import make_calculator
 from motep.io.mlip.cfg import read_cfg
 from motep.io.mlip.mtp import read_mtp
 from motep.parallel import world
@@ -22,20 +22,26 @@ fmt = "{:20s}"
 setup_map = {
     "numpy": {"engine": "numpy"},
     "numba": {"engine": "numba"},
-    "numba_train": {"engine": "numba", "mode": "train"},
+    "numba_train": {"engine": "numba", "jac": True},
     "numba_mag": {"engine": "numba", "magnetic": True},
-    "numba_mag_train": {"engine": "numba", "mode": "train", "magnetic": True},
+    "numba_mag_train": {"engine": "numba", "jac": True, "magnetic": True},
     "numba_mag_train_mgrad": {
         "engine": "numba",
-        "mode": "train_mgrad",
+        "jac": True,
+        "mgrad": True,
         "magnetic": True,
     },
     "jax": {"engine": "jax"},
     "cext": {"engine": "cext"},
-    "cext_train": {"engine": "cext", "mode": "train"},
+    "cext_train": {"engine": "cext", "jac": True},
     "cext_mag": {"engine": "cext", "magnetic": True},
-    "cext_mag_train": {"engine": "cext", "mode": "train", "magnetic": True},
-    "cext_mag_train_mgrad": {"engine": "cext", "mode": "train_mgrad", "magnetic": True},
+    "cext_mag_train": {"engine": "cext", "jac": True, "magnetic": True},
+    "cext_mag_train_mgrad": {
+        "engine": "cext",
+        "jac": True,
+        "mgrad": True,
+        "magnetic": True,
+    },
 }
 
 all_setups = [
@@ -112,7 +118,8 @@ def _time_mtp(
     images: list[Atoms],
     *,
     engine: str,
-    mode: str = "run",
+    jac: bool = False,
+    mgrad: bool = False,
     magnetic: bool = False,
 ) -> np.ndarray:
     mtp_data = read_mtp(pot_path)
@@ -128,18 +135,30 @@ def _time_mtp(
         if atomic_number not in species:
             species.append(atomic_number)
     mtp_data.species = species
-    calc = MTP(mtp_data, engine=engine, mode=mode)
+    # The Jacobian pass requires a train-mode engine; ``mgrad`` needs train_mgrad.
+    mode = ("train_mgrad" if mgrad else "train") if jac else "run"
+    calc = make_calculator(mtp_data, engine=engine, mode=mode)
     calc.use_cache = False
 
-    suffix = f" ({'mag, ' if magnetic else ''}{mode})"
+    label = ("jac_mgrad" if mgrad else "jac") if jac else "efs"
+    suffix = f" ({'mag, ' if magnetic else ''}{label})"
+
+    def run_one(atoms: Atoms) -> float:
+        if not jac:
+            return calc.get_potential_energy(atoms)
+        if magnetic:
+            calc.compute_jacobian(atoms, mgrad=mgrad)
+        else:
+            calc.compute_jacobian(atoms)
+        return calc.results["energy"]
 
     # Make initial calc to not time things like compile time and things that are cachable
     with Timer(fmt.format(engine + suffix + " (0th)")):
-        calc.get_potential_energy(images[-1])
+        run_one(images[-1])
 
     comm.barrier()
     with Timer(fmt.format(engine + suffix)):
-        energies = [calc.get_potential_energy(_) for _ in images]
+        energies = [run_one(_) for _ in images]
         comm.barrier()
     return np.array(energies)
 

--- a/benchmarks/optimize.py
+++ b/benchmarks/optimize.py
@@ -1,0 +1,178 @@
+"""Benchmark the ``efs``/``jac`` passes an optimizer performs.
+
+For ``--optimizer minimize`` with a gradient it runs a warm A/B of two schemes:
+
+* ``split`` — ``fun`` is an ``efs`` (E/F/S) pass, ``jac`` a separate parameter-
+  Jacobian pass.
+* ``fused`` — ``fun`` returns ``(loss, jac)`` from a single Jacobian pass
+  (SciPy ``jac=True``), so the gradient is free and no redundant ``efs`` runs.
+
+Both paths are warmed first (geometry caches, basis-array allocation, etc), so
+the reported per-call costs exclude first-call overhead.
+
+    python benchmarks/optimize.py --level 2
+    python benchmarks/optimize.py --level 10 --stride 50
+
+Any other ``--optimizer`` (DE, DA, LLS, ...) is run once and instrumented.
+"""
+
+import argparse
+import pathlib
+import time
+
+import numpy as np
+from scipy.optimize import minimize
+
+from motep.io.mlip.cfg import read_cfg
+from motep.io.mlip.mtp import read_mtp
+from motep.loss import LossFunction, LossSetting
+from motep.optimizers import make_optimizer
+from motep.parallel import world
+
+_UNBOUNDED = {
+    "cg",
+    "bfgs",
+    "newton-cg",
+    "dogleg",
+    "trust-ncg",
+    "trust-exact",
+    "trust-krylov",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--data-path", type=pathlib.Path, default="tests/data_path")
+    p.add_argument("--crystal", default="multi")
+    p.add_argument("--level", type=int, default=2)
+    p.add_argument("--engine", default="cext")
+    p.add_argument("--stride", type=int, default=20, help="subsample the training set")
+    p.add_argument("--maxiter", type=int, default=25)
+    p.add_argument(
+        "--optimizer",
+        default="minimize",
+        help="make_optimizer name: minimize, DE, DA, LLS, Level2MTP, NI, randomize, GA",
+    )
+    p.add_argument("--method", default="BFGS", help="scipy method (minimize only)")
+    p.add_argument("--no-jac", action="store_true", help="finite-difference gradient")
+    p.add_argument("--seed", type=int, default=42)
+    return p.parse_args()
+
+
+def build(args: argparse.Namespace) -> tuple:
+    """Build a fresh, warmed loss + optimizer (identical start across runs)."""
+    fitting = args.data_path / f"fitting/crystals/{args.crystal}/{args.level:02d}"
+    training = args.data_path / f"original/crystals/{args.crystal}/training.cfg"
+    if not (fitting / "initial.mtp").exists():
+        raise SystemExit(f"missing {fitting / 'initial.mtp'}")
+
+    images = read_cfg(training, index=":")[:: args.stride]
+    mtp_data = read_mtp(fitting / "initial.mtp")
+    setting = LossSetting(energy_weight=1.0, forces_weight=0.01, stress_weight=0.001)
+    loss = LossFunction(
+        images, mtp_data=mtp_data, setting=setting, comm=world, engine=args.engine
+    )
+    optimizer = make_optimizer(args.optimizer)(loss)  # sets ``mtp_data.optimized``
+    mtp_data.initialize(rng=np.random.default_rng(args.seed))
+
+    # Warm up both engine paths: geometry caches, basis-array allocation, JIT.
+    loss.loss_and_jac(mtp_data.parameters)
+    loss(mtp_data.parameters)
+    return loss, optimizer, mtp_data, len(images)
+
+
+def instrument(loss) -> dict:
+    """Wrap the forward/jac passes to count and time them; returns the stats."""
+    stats = {"efs_n": 0, "efs_t": 0.0, "jac_n": 0, "jac_t": 0.0}
+    run, jac = loss._run_calculations, loss._run_jac_calculations
+
+    def timed(key, fn):
+        def wrapper():
+            t0 = time.perf_counter()
+            fn()
+            stats[f"{key}_t"] += time.perf_counter() - t0
+            stats[f"{key}_n"] += 1
+
+        return wrapper
+
+    loss._run_calculations = timed("efs", run)
+    loss._run_jac_calculations = timed("jac", jac)
+    return stats
+
+
+def run_minimize(args: argparse.Namespace, scheme: str) -> dict:
+    """Run ``scipy.minimize`` in the ``split`` or ``fused`` scheme (serial)."""
+    loss, _, mtp_data, _ = build(args)
+    stats = instrument(loss)
+    x0 = mtp_data.parameters
+    bounds = None if args.method.lower() in _UNBOUNDED else mtp_data.get_bounds()
+    opts = {"maxiter": args.maxiter}
+    t0 = time.perf_counter()
+    if scheme == "split":
+        minimize(
+            loss,
+            x0,
+            jac=loss.jac,
+            method=args.method,
+            bounds=bounds,
+            options=opts,
+        )
+    else:
+        minimize(
+            loss.loss_and_jac,
+            x0,
+            jac=True,
+            method=args.method,
+            bounds=bounds,
+            options=opts,
+        )
+    stats["wall"] = time.perf_counter() - t0
+    return stats
+
+
+def report(name: str, s: dict) -> None:
+    ef = s["efs_t"] / max(s["efs_n"], 1)
+    jf = s["jac_t"] / max(s["jac_n"], 1)
+    print(f"[{name}]")
+    print(f"  efs : {s['efs_n']:3d} calls  {ef * 1e3:7.2f} ms  {s['efs_t']:7.3f}s")
+    print(f"  jac : {s['jac_n']:3d} calls  {jf * 1e3:7.2f} ms  {s['jac_t']:7.3f}s")
+    print(f"  wall: {s['wall']:7.3f}s")
+
+
+def main() -> None:
+    args = parse_args()
+    _, _, _, n_img = build(args)
+    print(
+        f"\ncrystal={args.crystal} level={args.level} engine={args.engine} "
+        f"images={n_img} optimizer={args.optimizer}"
+    )
+
+    if args.optimizer == "minimize" and not args.no_jac:
+        print(f"method={args.method}  (warm split vs fused)\n")
+        split = run_minimize(args, "split")
+        fused = run_minimize(args, "fused")
+        report("split", split)
+        report("fused", fused)
+        dw = split["wall"] - fused["wall"]
+        print(
+            f"\nwall  split - fused : {dw:+.3f}s "
+            f"({100 * dw / max(fused['wall'], 1e-12):+.1f}%)"
+        )
+        return
+
+    loss, optimizer, _, _ = build(args)
+    stats = instrument(loss)
+    opt_kwargs = (
+        {"jac": False, "options": {"maxiter": args.maxiter}}
+        if args.optimizer == "minimize"
+        else {}
+    )
+    t0 = time.perf_counter()
+    optimizer.optimize(**opt_kwargs)
+    stats["wall"] = time.perf_counter() - t0
+    print()
+    report(args.optimizer, stats)
+
+
+if __name__ == "__main__":
+    main()

--- a/motep/calculator.py
+++ b/motep/calculator.py
@@ -1,19 +1,16 @@
 """ASE Calculators."""
 
 import importlib
-from typing import TYPE_CHECKING, ClassVar
+from typing import ClassVar
 
+import numpy as np
 from ase import Atoms
 from ase.calculators.calculator import Calculator, all_changes
 
+from motep.potentials.mmtp.base import MagEngineBase
 from motep.potentials.mmtp.data import MagMTPData
 from motep.potentials.mtp.base import EngineBase
 from motep.potentials.mtp.data import MTPData
-
-if TYPE_CHECKING:
-    import numpy as np
-
-    from motep.potentials.mmtp.base import MagEngineBase
 
 _ENGINES = {
     "numpy": "motep.potentials.mtp.numpy.engine.NumpyMTPEngine",

--- a/motep/calculator.py
+++ b/motep/calculator.py
@@ -1,13 +1,19 @@
 """ASE Calculators."""
 
-import numpy as np
+import importlib
+from typing import TYPE_CHECKING, ClassVar
+
 from ase import Atoms
 from ase.calculators.calculator import Calculator, all_changes
 
-from motep.potentials.mmtp.base import MagEngineBase
 from motep.potentials.mmtp.data import MagMTPData
 from motep.potentials.mtp.base import EngineBase
 from motep.potentials.mtp.data import MTPData
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from motep.potentials.mmtp.base import MagEngineBase
 
 _ENGINES = {
     "numpy": "motep.potentials.mtp.numpy.engine.NumpyMTPEngine",
@@ -36,17 +42,22 @@ def make_mtp_engine(
     magnetic : bool
         If True, return the magnetic variant of the engine.
 
-    """
-    import importlib
+    Raises
+    ------
+    ValueError
+        If the engine name is unknown or does not support magnetic potentials.
 
+    """
     registry = _MAGNETIC_ENGINES if magnetic else _ENGINES
     if engine not in registry:
         if magnetic:
-            raise ValueError(
+            msg = (
                 f"Engine {engine!r} does not support magnetic potentials. "
                 f"Supported: {sorted(_MAGNETIC_ENGINES)}"
             )
-        raise ValueError(f"Unknown engine {engine!r}. Supported: {sorted(_ENGINES)}")
+            raise ValueError(msg)
+        msg = f"Unknown engine {engine!r}. Supported: {sorted(_ENGINES)}"
+        raise ValueError(msg)
     module_path, _, class_name = registry[engine].rpartition(".")
     return getattr(importlib.import_module(module_path), class_name)
 
@@ -57,6 +68,7 @@ def make_calculator(
     mode: str = "run",
     *,
     relax_magmoms: bool | None = None,
+    static_geometry: bool = False,
     **kwargs: dict,
 ) -> "MTP | MMTP":
     """Create the appropriate calculator based on data type.
@@ -73,6 +85,8 @@ def make_calculator(
     relax_magmoms : bool or None
         Whether to relax magnetic moments.  ``None`` (default) resolves to
         ``True`` for ``mode="run"`` with magnetic data, ``False`` otherwise.
+    static_geometry : bool, default False
+        If True, the atomic geometry is assumed fixed across calls.
     **kwargs
         Forwarded to the calculator constructor (e.g. ``warm_start_magmoms``).
 
@@ -86,9 +100,20 @@ def make_calculator(
         if relax_magmoms is None:
             relax_magmoms = mode == "run"
         return MMTP(
-            mtp_data, engine=engine, mode=mode, relax_magmoms=relax_magmoms, **kwargs
+            mtp_data,
+            engine=engine,
+            mode=mode,
+            relax_magmoms=relax_magmoms,
+            static_geometry=static_geometry,
+            **kwargs,
         )
-    return MTP(mtp_data, engine=engine, mode=mode, **kwargs)
+    return MTP(
+        mtp_data,
+        engine=engine,
+        mode=mode,
+        static_geometry=static_geometry,
+        **kwargs,
+    )
 
 
 class MTP(Calculator):
@@ -102,23 +127,49 @@ class MTP(Calculator):
         "stress",
     )
 
+    # System changes that invalidate the frozen static-geometry vectors.
+    _geometry_changes: ClassVar[frozenset] = frozenset(
+        {"positions", "numbers", "cell", "pbc"},
+    )
+
     def __init__(
         self,
         mtp_data: MTPData,
         *args: tuple,
         engine: str = "cext",
         mode: str = "run",
+        static_geometry: bool = False,
         **kwargs: dict,
     ) -> None:
         super().__init__(*args, **kwargs)
         magnetic = isinstance(mtp_data, MagMTPData)
         engine_cls = make_mtp_engine(engine, magnetic=magnetic)
-        self.engine: EngineBase = engine_cls(mtp_data, mode=mode)
+        self.engine: EngineBase = engine_cls(
+            mtp_data,
+            mode=mode,
+            static_geometry=static_geometry,
+        )
 
     def update_parameters(self, mtp_data: MTPData) -> None:
         """Update MTP parameters."""
         if self.engine.update(mtp_data):
             self.results = {}
+
+    def _store(self, atoms: Atoms, results: dict) -> None:
+        self.results = results
+        self.results["free_energy"] = self.results["energy"]
+        if atoms.cell.rank != 3 and "stress" in self.results:  # noqa: PLR2004
+            del self.results["stress"]
+
+    def _guard_static_geometry(self, system_changes: list[str]) -> None:
+        if self.engine.geometry_frozen and self._geometry_changes.intersection(
+            system_changes,
+        ):
+            msg = (
+                "Atomic geometry changes not allowed when initialized with "
+                "static_geometry=True."
+            )
+            raise RuntimeError(msg)
 
     def calculate(
         self,
@@ -127,14 +178,15 @@ class MTP(Calculator):
         system_changes: list[str] = all_changes,
     ) -> None:
         """Calculate."""
+        self._guard_static_geometry(system_changes)
         super().calculate(atoms, properties, system_changes)
+        self._store(self.atoms, self.engine.efs(self.atoms))
 
-        self.results = self.engine.calculate(self.atoms)
-
-        self.results["free_energy"] = self.results["energy"]
-
-        if self.atoms.cell.rank != 3 and "stress" in self.results:
-            del self.results["stress"]
+    def compute_jacobian(self, atoms: Atoms) -> None:
+        """Run a Jacobian pass, populating engine basis data and results."""
+        self._guard_static_geometry(self.check_state(atoms))
+        Calculator.calculate(self, atoms)
+        self._store(atoms, self.engine.jac(atoms))
 
 
 class MMTP(MTP):
@@ -162,7 +214,7 @@ class MMTP(MTP):
 
     """
 
-    implemented_properties = (
+    implemented_properties: ClassVar[tuple] = (
         "energy",
         "free_energy",
         "energies",
@@ -172,7 +224,7 @@ class MMTP(MTP):
         "magmoms",
     )
 
-    default_parameters = {
+    default_parameters: ClassVar[dict] = {
         "relax_magmoms": False,
         "warm_start_magmoms": True,
     }
@@ -183,13 +235,18 @@ class MMTP(MTP):
         *args,
         engine: str = "cext",
         mode: str = "run",
+        static_geometry: bool = False,
         **kwargs,
     ) -> None:
         if not isinstance(mtp_data, MagMTPData):
             mtp_data = MagMTPData.from_base(mtp_data)
         Calculator.__init__(self, *args, **kwargs)
         engine_cls = make_mtp_engine(engine, magnetic=True)
-        self.engine: MagEngineBase = engine_cls(mtp_data, mode=mode)
+        self.engine: MagEngineBase = engine_cls(
+            mtp_data,
+            mode=mode,
+            static_geometry=static_geometry,
+        )
         self._relaxed_magmoms: np.ndarray | None = None
 
     def update_parameters(self, mtp_data: MagMTPData) -> None:
@@ -207,6 +264,7 @@ class MMTP(MTP):
         properties: list[str] = ["energy"],
         system_changes: list[str] = all_changes,
     ) -> None:
+        self._guard_static_geometry(system_changes)
         Calculator.calculate(self, atoms, properties, system_changes)
 
         relax = self.parameters.get("relax_magmoms", False)
@@ -223,14 +281,17 @@ class MMTP(MTP):
             else:
                 magmoms_init = None  # engine will read from atoms
 
-            self.results = self.engine.relax_magnetic_moments(
-                self.atoms, magmoms_init=magmoms_init
+            results = self.engine.relax_magnetic_moments(
+                self.atoms,
+                magmoms_init=magmoms_init,
             )
-            self._relaxed_magmoms = self.results["magmoms"].copy()
+            self._relaxed_magmoms = results["magmoms"].copy()
+            self._store(self.atoms, results)
         else:
-            self.results = self.engine.calculate(self.atoms)
+            self._store(self.atoms, self.engine.efs(self.atoms))
 
-        self.results["free_energy"] = self.results["energy"]
-
-        if self.atoms.cell.rank != 3 and "stress" in self.results:
-            del self.results["stress"]
+    def compute_jacobian(self, atoms: Atoms, *, mgrad: bool = False) -> None:
+        """Run a Jacobian pass, populating engine basis data and results."""
+        self._guard_static_geometry(self.check_state(atoms))
+        Calculator.calculate(self, atoms)  # refresh self.atoms baseline (copy)
+        self._store(atoms, self.engine.jac(atoms, mgrad=mgrad))

--- a/motep/grade/grader.py
+++ b/motep/grade/grader.py
@@ -87,7 +87,8 @@ class Grader:
             List of ASE Atoms objects to evaluate. Modified in-place.
 
         """
-        mode = "train" if "radial_coeffs" in self.mtp_data.optimized else "run"
+        need_jac = "radial_coeffs" in self.mtp_data.optimized
+        mode = "train" if need_jac else "run"
         for atoms in images:
             if atoms.calc is not None and "magmoms" in atoms.calc.results:
                 atoms.set_initial_magnetic_moments(atoms.calc.results["magmoms"])
@@ -97,7 +98,10 @@ class Grader:
                 mode=mode,
                 relax_magmoms=False,
             )
-            atoms.get_potential_energy()
+            if need_jac:
+                atoms.calc.compute_jacobian(atoms)
+            else:
+                atoms.get_potential_energy()
 
     def _calc_jacobian(self, images: list[Atoms]) -> np.ndarray:
         """Calculate the Jacobian of energies with respect to the parameters.

--- a/motep/loss.py
+++ b/motep/loss.py
@@ -11,7 +11,7 @@ from ase import Atoms
 from ase.stress import voigt_6_to_full_3x3_stress
 from scipy.constants import eV
 
-from motep.calculator import MMTP, make_calculator
+from motep.calculator import MMTP, MTP, make_calculator
 from motep.parallel import DummyMPIComm, world
 from motep.potentials.mmtp.data import MagMTPData
 from motep.potentials.mtp.data import MTPData
@@ -514,20 +514,24 @@ class LossFunctionBase(ABC):
             for i in range(ncnf):
                 root = i % size
                 if root != 0 and hasattr(self.images[i].calc, "engine"):
-                    engine = self.images[i].calc.engine
+                    calc: MTP = self.images[i].calc
+                    engine = calc.engine
                     engine.mbd = self.comm.recv(source=root, tag=i + ncnf)
                     engine.rbd = self.comm.recv(source=root, tag=i + 2 * ncnf)
-                    # received data were produced by a jac pass on ``root``
-                    engine._jac_valid = True
-                    if isinstance(self.images[i].calc, MMTP):
-                        engine._mgrad_valid = True
+                    cache = self.comm.recv(source=root, tag=i + 3 * ncnf)
+                    for name, value in cache.items():
+                        setattr(engine, name, value)
         else:
             for i in range(rank, ncnf, size):
                 if hasattr(self.images[i].calc, "engine"):
-                    self.comm.send(self.images[i].calc.engine.mbd, dest=0, tag=i + ncnf)
-                    self.comm.send(
-                        self.images[i].calc.engine.rbd, dest=0, tag=i + 2 * ncnf
-                    )
+                    calc: MTP = self.images[i].calc
+                    engine = calc.engine
+                    self.comm.send(engine.mbd, dest=0, tag=i + ncnf)
+                    self.comm.send(engine.rbd, dest=0, tag=i + 2 * ncnf)
+                    cache = {"_jac_valid": engine._jac_valid}
+                    if hasattr(engine, "_mgrad_valid"):
+                        cache["_mgrad_valid"] = engine._mgrad_valid
+                    self.comm.send(cache, dest=0, tag=i + 3 * ncnf)
 
     def _sum_loss(self) -> float:
         return (

--- a/motep/loss.py
+++ b/motep/loss.py
@@ -11,7 +11,7 @@ from ase import Atoms
 from ase.stress import voigt_6_to_full_3x3_stress
 from scipy.constants import eV
 
-from motep.calculator import make_calculator
+from motep.calculator import MMTP, make_calculator
 from motep.parallel import DummyMPIComm, world
 from motep.potentials.mmtp.data import MagMTPData
 from motep.potentials.mtp.data import MTPData
@@ -481,10 +481,21 @@ class LossFunctionBase(ABC):
         """Evaluate the loss function."""
 
     def _run_calculations(self) -> None:
-        """Run calculations of the properties."""
+        """Run energies/forces/stress calculations."""
         ncnf = len(self.images)
         for i in range(self.comm.rank, ncnf, self.comm.size):
             self.images[i].get_potential_energy()
+
+    def _run_jac_calculations(self) -> None:
+        """Run Jacobian passes, populating engine basis data on each image."""
+        ncnf = len(self.images)
+        for i in range(self.comm.rank, ncnf, self.comm.size):
+            atoms = self.images[i]
+            calc = atoms.calc
+            if isinstance(calc, MMTP):
+                calc.compute_jacobian(atoms, mgrad="mgrad" in calc.targets)
+            else:
+                calc.compute_jacobian(atoms)
 
     def broadcast_results(self) -> None:
         """Broadcast data."""
@@ -503,10 +514,13 @@ class LossFunctionBase(ABC):
             for i in range(ncnf):
                 root = i % size
                 if root != 0 and hasattr(self.images[i].calc, "engine"):
-                    mbd = self.comm.recv(source=root, tag=i + ncnf)
-                    self.images[i].calc.engine.mbd = mbd
-                    rbd = self.comm.recv(source=root, tag=i + 2 * ncnf)
-                    self.images[i].calc.engine.rbd = rbd
+                    engine = self.images[i].calc.engine
+                    engine.mbd = self.comm.recv(source=root, tag=i + ncnf)
+                    engine.rbd = self.comm.recv(source=root, tag=i + 2 * ncnf)
+                    # received data were produced by a jac pass on ``root``
+                    engine._jac_valid = True
+                    if isinstance(self.images[i].calc, MMTP):
+                        engine._mgrad_valid = True
         else:
             for i in range(rank, ncnf, size):
                 if hasattr(self.images[i].calc, "engine"):
@@ -514,6 +528,14 @@ class LossFunctionBase(ABC):
                     self.comm.send(
                         self.images[i].calc.engine.rbd, dest=0, tag=i + 2 * ncnf
                     )
+
+    def _sum_loss(self) -> float:
+        return (
+            self.setting.energy_weight * self.loss_energy.calculate()
+            + self.setting.forces_weight * self.loss_forces.calculate()
+            + self.setting.stress_weight * self.loss_stress.calculate()
+            + self.setting.mgrad_weight * self.loss_mgrad.calculate()
+        )
 
     def calc_loss_function(self) -> float:
         """Calculate the value of the loss function.
@@ -524,21 +546,10 @@ class LossFunctionBase(ABC):
 
         """
         self._run_calculations()
-        return (
-            self.setting.energy_weight * self.loss_energy.calculate()
-            + self.setting.forces_weight * self.loss_forces.calculate()
-            + self.setting.stress_weight * self.loss_stress.calculate()
-            + self.setting.mgrad_weight * self.loss_mgrad.calculate()
-        )
+        return self._sum_loss()
 
-    def jac(self, parameters: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
-        """Calculate the Jacobian of the loss function.
-
-        Returns
-        -------
-        npt.NDArray[np.float64]
-
-        """
+    def _sum_jac(self) -> npt.NDArray[np.float64]:
+        """Weighted sum of the per-property Jacobians (basis data must be current)."""
         jac = self.setting.energy_weight * self.loss_energy.jac()
         if self.loss_forces.idcs_frc.size and self.setting.forces_weight:
             jac += self.setting.forces_weight * self.loss_forces.jac()
@@ -723,6 +734,7 @@ class LossFunction(LossFunctionBase):
                 engine=self.engine,
                 mode=mode,
                 relax_magmoms=relax_magmoms,
+                static_geometry=True,
             )
             atoms.calc.targets = targets
             # Special handling of magmoms, since they can be both results and input
@@ -730,8 +742,33 @@ class LossFunction(LossFunctionBase):
                 atoms.set_initial_magnetic_moments(targets["magmoms"])
 
     def __call__(self, parameters: list[float]) -> float:
+        """Evaluate the loss function."""
         parameters = self.comm.bcast(parameters, root=0)
         self.mtp_data.parameters = parameters
         for atoms in self.images:
             atoms.calc.update_parameters(self.mtp_data)
         return self.calc_loss_function()
+
+    def _jacobian_pass(self, parameters: list[float]) -> None:
+        parameters = self.comm.bcast(parameters, root=0)
+        self.mtp_data.parameters = parameters
+        for atoms in self.images:
+            atoms.calc.update_parameters(self.mtp_data)
+        self._run_jac_calculations()
+
+    def calc_basis(self, parameters: list[float]) -> float:
+        """Populate engine basis data and return the loss value."""
+        self._jacobian_pass(parameters)
+        return self._sum_loss()
+
+    def jac(self, parameters: list[float]) -> npt.NDArray[np.float64]:
+        """Populate engine basis data and return the summed loss Jacobian."""
+        self._jacobian_pass(parameters)
+        return self._sum_jac()
+
+    def loss_and_jac(
+        self, parameters: list[float]
+    ) -> tuple[float, npt.NDArray[np.float64]]:
+        """Return ``(loss, jac)`` from a single Jacobian pass."""
+        self._jacobian_pass(parameters)
+        return self._sum_loss(), self._sum_jac()

--- a/motep/optimizers/base.py
+++ b/motep/optimizers/base.py
@@ -101,8 +101,11 @@ class ParallelOptimizerBase(OptimizerBase):
 
     _OP_LOSS = 0
     _OP_JAC = 1
-    _OP_GATHER = 2
-    _OP_STOP = 3
+    _OP_BASIS = 2
+    _OP_LOSS_JAC = 3
+
+    _OP_GATHER = 4
+    _OP_STOP = 5
 
     def rank0_loss(self, parameters: npt.NDArray[np.float64]) -> float:
         """Evaluate the loss function, signaling workers first.
@@ -129,6 +132,19 @@ class ParallelOptimizerBase(OptimizerBase):
         self.loss.comm.bcast(self._OP_JAC, root=0)
         return self.loss.jac(parameters)
 
+    def rank0_basis(self, parameters: npt.NDArray[np.float64]) -> float:
+        """Populate engine basis data (returns the loss value), signaling workers."""
+        self.loss.comm.bcast(self._OP_BASIS, root=0)
+        return self.loss.calc_basis(parameters)
+
+    def rank0_loss_and_jac(
+        self,
+        parameters: npt.NDArray[np.float64],
+    ) -> tuple[float, npt.NDArray[np.float64]]:
+        """Evaluate loss and Jacobian in one pass, signaling workers first."""
+        self.loss.comm.bcast(self._OP_LOSS_JAC, root=0)
+        return self.loss.loss_and_jac(parameters)
+
     def rank0_gather_data(self) -> None:
         """Gather data to rank 0, signaling workers first."""
         self.loss.comm.bcast(self._OP_GATHER, root=0)
@@ -149,6 +165,10 @@ class ParallelOptimizerBase(OptimizerBase):
                 self.loss(None)
             elif op == self._OP_JAC:
                 self.loss.jac(None)
+            elif op == self._OP_BASIS:
+                self.loss.calc_basis(None)
+            elif op == self._OP_LOSS_JAC:
+                self.loss.loss_and_jac(None)
             elif op == self._OP_GATHER:
                 self.loss.gather_data()
 

--- a/motep/optimizers/level2mtp.py
+++ b/motep/optimizers/level2mtp.py
@@ -39,7 +39,7 @@ class Level2MTPOptimizer(LLSOptimizerBase):
         callback = self.callback = Callback(self.loss)
 
         # Calculate basis functions of `loss.images`
-        loss_value = self.rank0_loss(parameters)
+        loss_value = self.rank0_basis(parameters)
         self.rank0_gather_data()
 
         # Print the value of the loss function.
@@ -114,7 +114,7 @@ class Level2MTPOptimizer(LLSOptimizerBase):
         species_count = mtp_data.species_count
         nrb = mtp_data.radial_coeffs.shape[3]
         size = species_count * species_count * nrb
-        matrix = np.stack([atoms.calc.engine.rbd.values for atoms in images])
+        matrix = np.stack([atoms.calc.engine.get_rbd().values for atoms in images])
         if self.loss.setting.energy_per_atom:
             cs = self.loss.loss_energy.inverse_numbers_of_atoms
             matrix *= cs[:, None, None, None]
@@ -137,7 +137,7 @@ class Level2MTPOptimizer(LLSOptimizerBase):
             matrix = np.hstack(
                 [
                     (
-                        images[i].calc.engine.rbd.dqdris.transpose(3, 4, 0, 1, 2)
+                        images[i].calc.engine.get_rbd().dqdris.transpose(3, 4, 0, 1, 2)
                         * sqrt(self.loss.loss_forces.inverse_numbers_of_atoms[i])
                     ).flat
                     for i in idcs
@@ -146,7 +146,7 @@ class Level2MTPOptimizer(LLSOptimizerBase):
         else:
             matrix = np.hstack(
                 [
-                    images[i].calc.engine.rbd.dqdris.transpose(3, 4, 0, 1, 2).flat
+                    images[i].calc.engine.get_rbd().dqdris.transpose(3, 4, 0, 1, 2).flat
                     for i in idcs
                 ],
             )
@@ -162,7 +162,7 @@ class Level2MTPOptimizer(LLSOptimizerBase):
         nrb = self.loss.mtp_data.radial_coeffs.shape[3]
         size = species_count * species_count * nrb
 
-        matrix = np.array([images[i].calc.engine.rbd.dqdeps.T for i in idcs])
+        matrix = np.array([images[i].calc.engine.get_rbd().dqdeps.T for i in idcs])
         if self.loss.setting.stress_times_volume:
             matrix = (matrix.T * self.loss.loss_stress.volumes[idcs]).T
             if self.loss.setting.energy_per_atom:
@@ -184,11 +184,16 @@ class Level2MTPOptimizer(LLSOptimizerBase):
         images = self.loss.images
         idcs = self.loss.loss_mgrad.idcs_mgd
 
+        def _get_rbd(i: int) -> npt.NDArray[np.float64]:
+            return (
+                images[i].calc.engine.get_rbd(mgrad=True).dqdmis.transpose(3, 0, 1, 2)
+            )
+
         if self.loss.setting.forces_per_atom:
             matrix = np.hstack(
                 [
                     (
-                        images[i].calc.engine.rbd.dqdmis.transpose(3, 0, 1, 2)
+                        _get_rbd(i)
                         * sqrt(self.loss.loss_mgrad.inverse_numbers_of_atoms[i])
                     ).flat
                     for i in idcs
@@ -196,10 +201,7 @@ class Level2MTPOptimizer(LLSOptimizerBase):
             )
         else:
             matrix = np.hstack(
-                [
-                    images[i].calc.engine.rbd.dqdmis.transpose(3, 0, 1, 2).flat
-                    for i in idcs
-                ],
+                [_get_rbd(i).flat for i in idcs],
             )
         if self.loss.setting.forces_per_conf:
             matrix /= sqrt(len(images))

--- a/motep/optimizers/lls.py
+++ b/motep/optimizers/lls.py
@@ -285,7 +285,7 @@ class LLSOptimizer(LLSOptimizerBase):
         callback = self.callback = Callback(self.loss)
 
         # Calculate basis functions of `loss.images`
-        loss_value = self.rank0_loss(parameters)
+        loss_value = self.rank0_basis(parameters)
         self.rank0_gather_data()
 
         # Print the value of the loss function.
@@ -348,7 +348,7 @@ class LLSOptimizer(LLSOptimizerBase):
 
     def _calc_matrix_energy(self) -> np.ndarray:
         images = self.loss.images
-        matrix = np.array([atoms.calc.engine.mbd.values for atoms in images])
+        matrix = np.array([atoms.calc.engine.get_mbd().values for atoms in images])
         if self.loss.setting.energy_per_atom:
             matrix *= self.loss.loss_energy.inverse_numbers_of_atoms[:, None]
         if self.loss.setting.energy_per_conf:
@@ -363,14 +363,17 @@ class LLSOptimizer(LLSOptimizerBase):
         if self.loss.setting.forces_per_atom:
             matrix = np.vstack(
                 [
-                    images[i].calc.engine.mbd.dbdris.transpose(1, 2, 0)
+                    images[i].calc.engine.get_mbd().dbdris.transpose(1, 2, 0)
                     * sqrt(self.loss.loss_forces.inverse_numbers_of_atoms[i])
                     for i in idcs_frc
                 ],
             )
         else:
             matrix = np.vstack(
-                [images[i].calc.engine.mbd.dbdris.transpose(1, 2, 0) for i in idcs_frc],
+                [
+                    images[i].calc.engine.get_mbd().dbdris.transpose(1, 2, 0)
+                    for i in idcs_frc
+                ],
             )
         if self.loss.setting.forces_per_conf:
             matrix /= sqrt(len(images))
@@ -379,7 +382,7 @@ class LLSOptimizer(LLSOptimizerBase):
     def _calc_matrix_stress(self) -> np.ndarray:
         images = self.loss.images
         idcs_str = self.loss.loss_stress.idcs_str
-        matrix = np.array([images[i].calc.engine.mbd.dbdeps.T for i in idcs_str])
+        matrix = np.array([images[i].calc.engine.get_mbd().dbdeps.T for i in idcs_str])
         if self.loss.setting.stress_times_volume:
             matrix = (matrix.T * self.loss.loss_stress.volumes[idcs_str]).T
             if self.loss.setting.energy_per_atom:
@@ -398,14 +401,17 @@ class LLSOptimizer(LLSOptimizerBase):
         if self.loss.setting.forces_per_atom:
             matrix = np.vstack(
                 [
-                    images[i].calc.engine.mbd.dbdmis.transpose(1, 0)
+                    images[i].calc.engine.get_mbd(mgrad=True).dbdmis.transpose(1, 0)
                     * sqrt(self.loss.loss_mgrad.inverse_numbers_of_atoms[i])
                     for i in idcs_mmg
                 ],
             )
         else:
             matrix = np.vstack(
-                [images[i].calc.engine.mbd.dbdmis.transpose(1, 0) for i in idcs_mmg],
+                [
+                    images[i].calc.engine.get_mbd(mgrad=True).dbdmis.transpose(1, 0)
+                    for i in idcs_mmg
+                ],
             )
         if self.loss.setting.forces_per_conf:
             matrix /= sqrt(len(images))

--- a/motep/optimizers/scipy.py
+++ b/motep/optimizers/scipy.py
@@ -115,12 +115,10 @@ class ScipyMinimizeOptimizer(ScipyOptimizerBase):
         callback = self.callback = Callback(self.loss)
         callback(OptimizeResult(x=parameters, fun=self.rank0_loss(parameters)))
 
-        kwargs["jac"] = kwargs.get("jac", True)
-        if kwargs["jac"]:
-            if "scaling" in self.optimized:
-                msg = "`jac` cannot (so far) be used to optimize `scaling`."
-                raise ValueError(msg)
-            kwargs["jac"] = self.rank0_jac
+        use_jac = kwargs.get("jac", True)
+        if use_jac and "scaling" in self.optimized:
+            msg = "`jac` cannot (so far) be used to optimize `scaling`."
+            raise ValueError(msg)
         if kwargs.get("method", "").lower() in {
             "cg",
             "bfgs",
@@ -132,8 +130,11 @@ class ScipyMinimizeOptimizer(ScipyOptimizerBase):
         }:
             bounds = None
 
+        kwargs["jac"] = use_jac
+        fun = self.rank0_loss_and_jac if use_jac else self.rank0_loss
+
         result = minimize(
-            self.rank0_loss,
+            fun,
             parameters,
             bounds=bounds,
             callback=callback,

--- a/motep/potentials/mmtp/base.py
+++ b/motep/potentials/mmtp/base.py
@@ -89,10 +89,10 @@ class MagMomentBasisData(MagModeBase, MomentBasisData):
             self.dbdmis = np.full((asm, natoms), np.nan)
             self.dgmdcs = np.full((spc, spc, rfc, nrb, natoms), np.nan)
 
-    def clean(self) -> None:
+    def clean(self, *, jac: bool = True, mgrad: bool = True) -> None:
         """Clean up moment basis properties."""
-        super().clean()
-        if self.mode == "train_mgrad":
+        super().clean(jac=jac)
+        if mgrad and self.mode == "train_mgrad":
             self.dbdmis[...] = 0.0
             self.dgmdcs[...] = 0.0
 
@@ -129,10 +129,10 @@ class MagRadialBasisData(MagModeBase, RadialBasisData):
         if self.mode == "train_mgrad":
             self.dqdmis = np.full((spc, spc, nrb, natoms), np.nan)
 
-    def clean(self) -> None:
+    def clean(self, *, jac: bool = True, mgrad: bool = True) -> None:
         """Clean up radial basis properties."""
-        super().clean()
-        if self.mode == "train_mgrad":
+        super().clean(jac=jac)
+        if mgrad and self.mode == "train_mgrad":
             self.dqdmis[...] = 0.0
 
 
@@ -144,6 +144,7 @@ class MagEngineBase(MagModeBase, EngineBase):
         mtp_data: MagMTPData,
         *,
         mode: str = "run",
+        static_geometry: bool = False,
     ) -> None:
         """Magnetic MTP as described in [Novikov_nCM_2022_Magnetic]_.
 
@@ -152,9 +153,12 @@ class MagEngineBase(MagModeBase, EngineBase):
         mtp_data : :class:`motep.potentials.mtp.data.MTPData`
             Parameters in the MLIP .mtp file.
         mode : {'run', 'train', 'train_mgrad'}, default 'run'
-            Mode of operation. 'train' computes and stores basis data for
-            training; 'train_mgrad' additionally computes basis data for
-            training to magnetic gradients; 'run' is the default runtime mode.
+            Capability of the engine. ``'train'`` allocates the parameter-
+            Jacobian basis data (``jac`` permitted); ``'train_mgrad'`` also
+            allocates the magnetic-gradient Jacobian (``jac(mgrad=True)``);
+            ``'run'`` allocates only what ``efs`` needs.
+        static_geometry : bool, default False
+            If True, the atomic geometry is assumed fixed across calls.
 
         .. [Novikov_nCM_2022_Magnetic]
             I. Novikov, Blazej Grabowski, Fritz Körmann and A. V. Shapeev, npj Comput. Mater. 8, 13 (2022).
@@ -165,12 +169,48 @@ class MagEngineBase(MagModeBase, EngineBase):
         self.results = {}
         self.neighbor_list = None
         self.mode = mode
+        self.static_geometry = static_geometry
+        self._jac_valid = False
+        self._mgrad_valid = False
 
         # moment basis data
         self.mbd = MagMomentBasisData(mode=mode)
 
         # used for `Level2MTPOptimizer`
         self.rbd = MagRadialBasisData(mode=mode)
+
+    def _require_train(self, *, mgrad: bool = False) -> None:
+        if "train" not in self.mode:
+            msg = f"jac() requires a train-mode engine, got mode={self.mode!r}."
+            raise RuntimeError(msg)
+        if mgrad and self.mode != "train_mgrad":
+            msg = (
+                "jac(mgrad=True) requires a 'train_mgrad' engine, got "
+                f"mode={self.mode!r}."
+            )
+            raise RuntimeError(msg)
+
+    def _require_mgrad(self) -> None:
+        if not self._mgrad_valid:
+            msg = (
+                "magnetic-gradient Jacobian data is stale; call jac(mgrad=True) "
+                "before reading it."
+            )
+            raise RuntimeError(msg)
+
+    def get_mbd(self, *, mgrad: bool = False) -> "MagMomentBasisData":
+        """Return the moment basis data, asserting the Jacobian is current."""
+        mbd = super().get_mbd()
+        if mgrad:
+            self._require_mgrad()
+        return mbd
+
+    def get_rbd(self, *, mgrad: bool = False) -> "MagRadialBasisData":
+        """Return the radial basis data, asserting the Jacobian is current."""
+        rbd = super().get_rbd()
+        if mgrad:
+            self._require_mgrad()
+        return rbd
 
     def update(self, mtp_data: MagMTPData) -> bool:
         """Update MTP parameters.
@@ -182,42 +222,59 @@ class MagEngineBase(MagModeBase, EngineBase):
 
         """
         self.mtp_data: MagMTPData = mtp_data
-        return super().update(mtp_data)
+        changed = super().update(mtp_data)
+        if changed:  # stored magnetic-gradient Jacobian no longer matches params
+            self._mgrad_valid = False
+        return changed
 
-    def calculate(
-        self, atoms: Atoms, magmoms: npt.NDArray[np.float64] | None = None
+    def efs(self, atoms: Atoms, magmoms: npt.NDArray[np.float64] | None = None) -> dict:
+        """Compute energies, forces, stress and the magnetic gradient."""
+        return self._run_mag(atoms, magmoms, jac=False, mgrad=False)
+
+    def jac(
+        self,
+        atoms: Atoms,
+        magmoms: npt.NDArray[np.float64] | None = None,
+        *,
+        mgrad: bool = False,
     ) -> dict:
-        """Calculate properties of the given system.
+        """Compute results and populate the parameter-Jacobian basis data.
 
-        Parameters
-        ----------
-        atoms : Atoms
-            The atomic structure.
-        magmoms : np.ndarray or None
-            Magnetic moments to use. If None, reads from
-            ``atoms.get_initial_magnetic_moments()``.
-
-        Returns
-        -------
-        Dictionary with energies, energy, forces and stress.
-
+        With ``mgrad`` the magnetic-gradient Jacobian is populated as well
+        (requires a ``train_mgrad`` engine).
         """
+        self._require_train(mgrad=mgrad)
+        return self._run_mag(atoms, magmoms, jac=True, mgrad=mgrad)
+
+    def _run_mag(
+        self,
+        atoms: Atoms,
+        magmoms: npt.NDArray[np.float64] | None,
+        *,
+        jac: bool,
+        mgrad: bool,
+    ) -> dict:
         self.check_species(atoms)
         if self.update_neighbor_list(atoms):
             self.initialize_basis_data(atoms)
 
         magmoms = _ensure_collinear_magmoms(atoms, magmoms)
 
-        energies, forces, stress, mgrad = self._calculate(atoms, magmoms=magmoms)
+        energies, forces, stress, mg = self._calculate(
+            atoms, magmoms, jac=jac, mgrad=mgrad
+        )
 
-        self._symmetrize_stress(atoms, stress)
+        self._symmetrize_stress(atoms, stress, jac=jac)
 
+        self.results = {}
         self.results["energies"] = energies
         self.results["energy"] = self.results["energies"].sum()
         self.results["forces"] = forces
         self.results["stress"] = stress.flat[[0, 4, 8, 5, 2, 1]]
-        self.results["mgrad"] = mgrad
+        self.results["mgrad"] = mg
 
+        self._jac_valid = jac
+        self._mgrad_valid = jac and mgrad
         return self.results
 
     def jac_mgrad(self, atoms: Atoms) -> Jacobian:
@@ -226,6 +283,7 @@ class MagEngineBase(MagModeBase, EngineBase):
         `jac.parameters` have the shape of `(nparams, natoms)`.
 
         """
+        self._require_mgrad()
         spc = self.mtp_data.species_count
         number_of_atoms = len(atoms)
 
@@ -267,7 +325,12 @@ class MagEngineBase(MagModeBase, EngineBase):
             self.initialize_basis_data(atoms)
 
         def objective_and_grad(moms: np.ndarray) -> tuple[float, np.ndarray]:
-            energies, _, _, mgrad = self._calculate(atoms, magmoms=moms)
+            energies, _, _, mgrad = self._calculate(
+                atoms,
+                moms,
+                jac=False,
+                mgrad=False,
+            )
             return float(energies.sum()), mgrad
 
         min_mag = mtp_data.magnetic_basis.min
@@ -281,7 +344,7 @@ class MagEngineBase(MagModeBase, EngineBase):
             bounds=bounds,
         )
         relaxed_magmoms = result.x
-        results = self.calculate(atoms, magmoms=relaxed_magmoms)
+        results = self.efs(atoms, relaxed_magmoms)
         results["magmoms"] = relaxed_magmoms
         results["magmom"] = relaxed_magmoms.sum()
         return results

--- a/motep/potentials/mmtp/cext/engine.py
+++ b/motep/potentials/mmtp/cext/engine.py
@@ -25,15 +25,19 @@ class CExtMagMTPEngine(MagEngineBase):
     but uses compiled C code for better performance in some scenarios.
     """
 
-    def _calculate(self, atoms: Atoms, magmoms: np.ndarray) -> tuple:
-        """Main calculation dispatch."""
-        if self.mode == "run":
+    def _calculate(
+        self,
+        atoms: Atoms,
+        magmoms: np.ndarray,
+        *,
+        jac: bool,
+        mgrad: bool,
+    ) -> tuple:
+        if not jac:
             return self._calc_mag_run(atoms, magmoms)
-        if self.mode == "train":
-            return self._calc_mag_train(atoms, magmoms)
-        if self.mode == "train_mgrad":
+        if mgrad:
             return self._calc_mag_train_mgrad(atoms, magmoms)
-        raise NotImplementedError(self.mode)
+        return self._calc_mag_train(atoms, magmoms)
 
     def _calc_mag_run(self, atoms: Atoms, magmoms: np.ndarray) -> tuple:
         """Calculate energies, forces, stress, and magnetic gradients for run mode."""
@@ -46,8 +50,8 @@ class CExtMagMTPEngine(MagEngineBase):
         itypes = get_types(atoms, mtp_data.species)
         jtypes = itypes[js]
 
-        self.mbd.clean()
-        self.rbd.clean()
+        self.mbd.clean(jac=False, mgrad=False)
+        self.rbd.clean(jac=False, mgrad=False)
 
         energies, gradient, grad_mag_i, grad_mag_j = _mmtp_cext.calc_mag_run(
             js,
@@ -76,8 +80,8 @@ class CExtMagMTPEngine(MagEngineBase):
         itypes = get_types(atoms, mtp_data.species)
         jtypes = itypes[js]
 
-        self.mbd.clean()
-        self.rbd.clean()
+        self.mbd.clean(jac=True, mgrad=False)
+        self.rbd.clean(jac=True, mgrad=False)
 
         energies = _mmtp_cext.calc_mag_train(
             js,
@@ -123,8 +127,8 @@ class CExtMagMTPEngine(MagEngineBase):
         itypes = get_types(atoms, mtp_data.species)
         jtypes = itypes[js]
 
-        self.rbd.clean()
-        self.mbd.clean()
+        self.rbd.clean(jac=True, mgrad=True)
+        self.mbd.clean(jac=True, mgrad=True)
 
         energies = _mmtp_cext.calc_mag_train_mgrad(
             js,

--- a/motep/potentials/mmtp/numba/engine.py
+++ b/motep/potentials/mmtp/numba/engine.py
@@ -37,14 +37,19 @@ from .moment import (
 class NumbaMagMTPEngine(MagEngineBase):
     """MTP Engine based on Numba."""
 
-    def _calculate(self, atoms: Atoms, magmoms: np.ndarray) -> tuple:
-        if self.mode == "run":
+    def _calculate(
+        self,
+        atoms: Atoms,
+        magmoms: np.ndarray,
+        *,
+        jac: bool,
+        mgrad: bool,
+    ) -> tuple:
+        if not jac:
             return self._calc_mag_run(atoms, magmoms)
-        if self.mode == "train":
-            return self._calc_mag_train(atoms, magmoms)
-        if self.mode == "train_mgrad":
+        if mgrad:
             return self._calc_mag_train_mgrad(atoms, magmoms)
-        raise NotImplementedError(self.mode)
+        return self._calc_mag_train(atoms, magmoms)
 
     def _calc_mag_run(self, atoms: Atoms, magmoms: np.ndarray) -> tuple:
         mtp_data = self.mtp_data
@@ -57,8 +62,8 @@ class NumbaMagMTPEngine(MagEngineBase):
         itypes = get_types(atoms, mtp_data.species)
         jtypes = itypes[js]
 
-        self.mbd.clean()
-        self.rbd.clean()
+        self.mbd.clean(jac=False, mgrad=False)
+        self.rbd.clean(jac=False, mgrad=False)
 
         energies, lgrads, mgrad_i, mgrad_j = _calc_mag_run(
             js,
@@ -100,8 +105,8 @@ class NumbaMagMTPEngine(MagEngineBase):
         itypes = get_types(atoms, mtp_data.species)
         jtypes = itypes[js]
 
-        self.mbd.clean()
-        self.rbd.clean()
+        self.mbd.clean(jac=True, mgrad=False)
+        self.rbd.clean(jac=True, mgrad=False)
 
         energies = _calc_mag_train(
             js,
@@ -178,8 +183,8 @@ class NumbaMagMTPEngine(MagEngineBase):
         itypes = get_types(atoms, mtp_data.species)
         jtypes = itypes[js]
 
-        self.mbd.clean()
-        self.rbd.clean()
+        self.mbd.clean(jac=True, mgrad=True)
+        self.rbd.clean(jac=True, mgrad=True)
 
         energies = _calc_mag_train_mgrad(
             js,

--- a/motep/potentials/mtp/base.py
+++ b/motep/potentials/mtp/base.py
@@ -207,7 +207,7 @@ class EngineWithNeighborlist(ModeBase):
         self.neighbor_list.update(atoms.pbc, atoms.cell, atoms.positions)
         self._neighbors, self._offsets = self._get_neighbors_and_offsets(atoms)
 
-    def update_neighbor_list(self, atoms: Atoms) -> None:
+    def update_neighbor_list(self, atoms: Atoms) -> bool:
         """Update the ASE `PrimitiveNeighborList` object.
 
         Notes

--- a/motep/potentials/mtp/base.py
+++ b/motep/potentials/mtp/base.py
@@ -104,10 +104,14 @@ class MomentBasisData(ModeBase):
             self.dgdcs = np.full((spc, spc, rfc, rbs, natoms, 3), np.nan)
             self.dsdcs = np.full((spc, spc, rfc, rbs, 3, 3), np.nan)
 
-    def clean(self) -> None:
-        """Clean up moment basis properties."""
+    def clean(self, *, jac: bool = True) -> None:
+        """Clean up moment basis properties.
+
+        ``jac`` (default True) also zeros the derivative arrays; pass False for
+        an ``efs`` pass, which does not touch them.
+        """
         self.vatoms[...] = 0.0
-        if "train" in self.mode:
+        if jac and "train" in self.mode:
             self.dbdris[...] = 0.0
             self.dbdeps[...] = 0.0
             self.dvdcs[...] = 0.0
@@ -144,9 +148,9 @@ class RadialBasisData(ModeBase):
             self.dqdris = np.full((spc, spc, rbs, natoms, 3), np.nan)
             self.dqdeps = np.full((spc, spc, rbs, 3, 3), np.nan)
 
-    def clean(self) -> None:
-        """Clean up radial basis properties."""
-        if "train" in self.mode:
+    def clean(self, *, jac: bool = True) -> None:
+        """Clean up radial basis properties (``jac=False`` skips the arrays)."""
+        if jac and "train" in self.mode:
             self.values[...] = 0.0
             self.dqdris[...] = 0.0
             self.dqdeps[...] = 0.0
@@ -181,9 +185,16 @@ class Jacobian:
 class EngineWithNeighborlist(ModeBase):
     """Class for getting interatomic vectors and hanling neighbor list."""
 
+    static_geometry: bool = False
+
     def __init__(self) -> None:
         self.neighbor_list: PrimitiveNeighborList | None = None
         self.mtp_data: MTPData = MTPData()
+
+    @property
+    def geometry_frozen(self) -> bool:
+        """True once the static-geometry vectors have been cached (frozen)."""
+        return self.static_geometry and hasattr(self, "_interatomic_vectors")
 
     def _initiate_neighbor_list(self, atoms: Atoms) -> None:
         """Initialize the ASE `PrimitiveNeighborList` object."""
@@ -201,12 +212,11 @@ class EngineWithNeighborlist(ModeBase):
 
         Notes
         -----
-        If in training mode, only the interatomic vectors are computed once, and
-        the neighborlist then discarded.
+        With ``static_geometry`` the interatomic vectors are computed once and
+        the neighborlist then discarded (the geometry is assumed fixed).
 
         """
-        # Special handling if in train mode
-        if "train" in self.mode:
+        if self.static_geometry:
             if not hasattr(self, "_interatomic_vectors"):
                 self._initiate_neighbor_list(atoms)
                 self._interatomic_vectors = self._get_interatomic_vectors(atoms)
@@ -224,7 +234,7 @@ class EngineWithNeighborlist(ModeBase):
         return False
 
     def _get_interatomic_vectors(self, atoms: Atoms) -> np.ndarray:
-        if "train" in self.mode and hasattr(self, "_interatomic_vectors"):
+        if self.static_geometry and hasattr(self, "_interatomic_vectors"):
             return self._interatomic_vectors
         max_dist = self.mtp_data.radial_basis.max
         positions = atoms.positions
@@ -273,16 +283,20 @@ class EngineBase(EngineWithNeighborlist):
         mtp_data: MTPData,
         *,
         mode: str = "run",
+        static_geometry: bool = False,
     ) -> None:
-        """MLIP-2 MTP.
+        """Moment tensor potential (MTP) engine.
 
         Parameters
         ----------
         mtp_data : :class:`motep.potentials.mtp.data.MTPData`
-            Parameters in the MLIP .mtp file.
+            Parameters of the MTP.
         mode : {'run', 'train'}, default 'run'
-            Mode of operation. `'train'` computes and stores basis data for
-            training; `'run'` is the default mode suitable for MD.
+            Capability of the engine. ``'train'`` allocates the parameter-
+            Jacobian basis data so that :meth:`jac` may be called; ``'run'``
+            allocates only what :meth:`efs` needs and forbids :meth:`jac`.
+        static_geometry : bool, default False
+            If True, the atomic geometry is assumed fixed across calls.
 
         """
         self._last_state: tuple | None = None
@@ -290,11 +304,10 @@ class EngineBase(EngineWithNeighborlist):
         self.results = {}
         self.neighbor_list = None
         self.mode = mode
+        self.static_geometry = static_geometry
+        self._jac_valid = False
 
-        # moment basis data
         self.mbd = MomentBasisData(mode=mode)
-
-        # used for `Level2MTPOptimizer`
         self.rbd = RadialBasisData(mode=mode)
 
     def update(self, mtp_data: MTPData) -> bool:
@@ -315,6 +328,8 @@ class EngineBase(EngineWithNeighborlist):
         state = mtp_data.basis_state()
         changed = not mtp_data.basis_state_equal(state, self._last_state)
         self._last_state = state
+        if changed:
+            self._jac_valid = False
         return changed
 
     def check_species(self, atoms: Atoms) -> None:
@@ -348,37 +363,56 @@ class EngineBase(EngineWithNeighborlist):
         self.rbd.initialize(natoms, self.mtp_data)
 
     @abstractmethod
-    def _calculate(self, atoms: Atoms) -> tuple: ...
+    def _calculate(self, atoms: Atoms, *, jac: bool) -> tuple: ...
 
-    def calculate(self, atoms: Atoms) -> dict:
-        """Calculate properties of the given system.
+    def _require_train(self) -> None:
+        if "train" not in self.mode:
+            msg = f"jac() requires a train-mode engine, got mode={self.mode!r}."
+            raise RuntimeError(msg)
 
-        Returns
-        -------
-        Dictionary with energies, energy, forces and stress.
+    def efs(self, atoms: Atoms) -> dict:
+        """Compute energies, forces, and stress."""
+        return self._run(atoms, jac=False)
 
+    def jac(self, atoms: Atoms) -> dict:
+        """Compute results and populate the parameter-Jacobian basis data.
+
+        Requires a ``train``-mode engine; the data are then readable via
+        :meth:`get_mbd` / :meth:`get_rbd` / ``jac_*`` until the next ``efs``.
         """
+        self._require_train()
+        return self._run(atoms, jac=True)
+
+    def _run(self, atoms: Atoms, *, jac: bool) -> dict:
         self.check_species(atoms)
         if self.update_neighbor_list(atoms):
             self.initialize_basis_data(atoms)
 
-        energies, forces, stress = self._calculate(atoms)
+        energies, forces, stress = self._calculate(atoms, jac=jac)
 
-        self._symmetrize_stress(atoms, stress)
+        self._symmetrize_stress(atoms, stress, jac=jac)
 
+        self.results = {}
         self.results["energies"] = energies
         self.results["energy"] = self.results["energies"].sum()
         self.results["forces"] = forces
         self.results["stress"] = stress.flat[[0, 4, 8, 5, 2, 1]]
 
+        self._jac_valid = jac
         return self.results
 
-    def _symmetrize_stress(self, atoms: Atoms, stress: np.ndarray) -> None:
+    def _symmetrize_stress(
+        self,
+        atoms: Atoms,
+        stress: np.ndarray,
+        *,
+        jac: bool,
+    ) -> None:
         if atoms.cell.rank == 3:  # noqa: PLR2004
             volume = atoms.get_volume()
             stress += stress.T
             stress *= 0.5 / volume
-            if "train" in self.mode:
+            if jac:
                 self.mbd.dbdeps += self.mbd.dbdeps.transpose(0, 2, 1)
                 self.mbd.dbdeps *= 0.5 / volume
                 self.mbd.dsdcs += self.mbd.dsdcs.swapaxes(-2, -1)
@@ -388,9 +422,28 @@ class EngineBase(EngineWithNeighborlist):
                 self.rbd.dqdeps *= 0.5 / volume
         else:
             stress[:, :] = np.nan
-            if "train" in self.mode:
+            if jac:
                 self.mbd.dbdeps[:, :, :] = np.nan
                 self.rbd.dqdeps[:, :, :] = np.nan
+
+    def _require_jac(self) -> None:
+        if not self._jac_valid:
+            msg = (
+                "basis-Jacobian data is stale: efs() ran after the last jac() "
+                "(or no jac() has run); call jac() before reading basis "
+                "derivatives."
+            )
+            raise RuntimeError(msg)
+
+    def get_mbd(self) -> "MomentBasisData":
+        """Return the moment basis data, asserting the Jacobian is current."""
+        self._require_jac()
+        return self.mbd
+
+    def get_rbd(self) -> "RadialBasisData":
+        """Return the radial basis data, asserting the Jacobian is current."""
+        self._require_jac()
+        return self.rbd
 
     def jac_energy(self, atoms: Atoms) -> MTPData:
         """Calculate the Jacobian of the energy with respect to the MTP parameters.
@@ -401,6 +454,8 @@ class EngineBase(EngineWithNeighborlist):
             Placeholder of the Jacobian of the energy with respect tothe MTP parameters.
 
         """
+        if "radial_coeffs" in self.mtp_data.optimized:
+            self._require_jac()  # only the radial part reads jac-only data
         sps = self.mtp_data.species
         nbs = list(atoms.numbers)
 
@@ -410,7 +465,7 @@ class EngineBase(EngineWithNeighborlist):
             species_coeffs=np.fromiter((nbs.count(s) for s in sps), dtype=float),
             radial_coeffs=self.mbd.dedcs.copy(),
             optimized=self.mtp_data.optimized,
-        )  # placeholder of the Jacobian with respect to the parameters
+        )
 
     def jac_energies(self, atoms: Atoms) -> Jacobian:
         """Calculate the Jacobian of local energies with respect to the MTP parameters.
@@ -421,6 +476,8 @@ class EngineBase(EngineWithNeighborlist):
             Jacobian whose ``parameters`` have the shape of `(nparams, natoms)`.
 
         """
+        if "radial_coeffs" in self.mtp_data.optimized:
+            self._require_jac()  # only the radial part reads jac-only data
         number_of_atoms = len(atoms)
         spicies_coeffs = np.full((self.mtp_data.species_count, number_of_atoms), np.nan)
         for i, s in enumerate(self.mtp_data.species):
@@ -443,6 +500,7 @@ class EngineBase(EngineWithNeighborlist):
             Jacobian whose ``parameters`` have the shape of `(nparams, natoms, 3)`.
 
         """
+        self._require_jac()
         spc = self.mtp_data.species_count
         number_of_atoms = len(atoms)
 
@@ -452,7 +510,7 @@ class EngineBase(EngineWithNeighborlist):
             species_coeffs=np.zeros((spc, number_of_atoms, 3)),
             radial_coeffs=self.mbd.dgdcs * -1.0,
             optimized=self.mtp_data.optimized,
-        )  # placeholder of the Jacobian with respect to the parameters
+        )
 
     def jac_stress(self, atoms: Atoms) -> Jacobian:
         """Calculate the Jacobian of the forces with respect to the MTP parameters.
@@ -463,6 +521,7 @@ class EngineBase(EngineWithNeighborlist):
             Jacobian whose ``parameters`` have the shape of `(nparams, 3, 3)`.
 
         """
+        self._require_jac()
         spc = self.mtp_data.species_count
 
         return Jacobian(
@@ -471,4 +530,4 @@ class EngineBase(EngineWithNeighborlist):
             species_coeffs=np.zeros((spc, 3, 3)),
             radial_coeffs=self.mbd.dsdcs.copy(),
             optimized=self.mtp_data.optimized,
-        )  # placeholder of the Jacobian with respect to the parameters
+        )

--- a/motep/potentials/mtp/cext/engine.py
+++ b/motep/potentials/mtp/cext/engine.py
@@ -27,13 +27,8 @@ class CExtMTPEngine(EngineBase):
         """Initialize the engine."""
         super().__init__(*args, **kwargs)
 
-    def _calculate(self, atoms: Atoms) -> tuple[np.ndarray, ...]:
-        """Main calculation dispatch."""
-        if self.mode == "run":
-            return self._calc_run(atoms)
-        if self.mode == "train":
-            return self._calc_train(atoms)
-        raise NotImplementedError(self.mode)
+    def _calculate(self, atoms: Atoms, *, jac: bool) -> tuple[np.ndarray, ...]:
+        return self._calc_train(atoms) if jac else self._calc_run(atoms)
 
     def _calc_run(self, atoms: Atoms) -> tuple[np.ndarray, ...]:
         """Calculate energies, forces, and stress for run mode.
@@ -51,8 +46,8 @@ class CExtMTPEngine(EngineBase):
         itypes = get_types(atoms, mtp_data.species)
         all_jtypes = itypes[all_js]
 
-        self.mbd.clean()
-        self.rbd.clean()
+        self.mbd.clean(jac=False)
+        self.rbd.clean(jac=False)
 
         energies, gradient = _mtp_cext.calc_run(
             all_js,

--- a/motep/potentials/mtp/jax/engine.py
+++ b/motep/potentials/mtp/jax/engine.py
@@ -47,7 +47,10 @@ class JaxMTPEngine(EngineBase):
             self.basis_converter.remap_mlip_moment_coeffs(self.mtp_data)
         return changed
 
-    def _calculate(self, atoms: Atoms) -> tuple:
+    def _calculate(self, atoms: Atoms, *, jac: bool) -> tuple:
+        if jac:
+            msg = "The jax engine does not support the parameter Jacobian."
+            raise NotImplementedError(msg)
         mtp_data = self.mtp_data
         itypes = jnp.array(get_types(atoms, mtp_data.species))
         js = jnp.array(self._neighbors)

--- a/motep/potentials/mtp/numba/engine.py
+++ b/motep/potentials/mtp/numba/engine.py
@@ -29,12 +29,8 @@ class NumbaMTPEngine(EngineBase):
         """Intialize the engine."""
         super().__init__(*args, **kwargs)
 
-    def _calculate(self, atoms: Atoms) -> tuple:
-        if self.mode == "run":
-            return self._calc_run(atoms)
-        if self.mode == "train":
-            return self._calc_train(atoms)
-        raise NotImplementedError(self.mode)
+    def _calculate(self, atoms: Atoms, *, jac: bool) -> tuple:
+        return self._calc_train(atoms) if jac else self._calc_run(atoms)
 
     def _calc_run(self, atoms: Atoms) -> tuple:
         mtp_data = self.mtp_data
@@ -45,8 +41,8 @@ class NumbaMTPEngine(EngineBase):
         itypes = get_types(atoms, mtp_data.species)
         jtypes = itypes[js]
 
-        self.mbd.clean()
-        self.rbd.clean()
+        self.mbd.clean(jac=False)
+        self.rbd.clean(jac=False)
 
         energies, gradient = _calc_run(
             rs,

--- a/motep/potentials/mtp/numpy/engine.py
+++ b/motep/potentials/mtp/numpy/engine.py
@@ -52,7 +52,7 @@ class NumpyMTPEngine(EngineBase):
         moment_basis = MomentBasis(self.mtp_data)
         return moment_basis.calculate(itype, jtypes, r_ijs, r_abs, self.rb)
 
-    def _calculate(self, atoms: Atoms) -> tuple:
+    def _calculate(self, atoms: Atoms, *, jac: bool) -> tuple:
         itypes = get_types(atoms, self.mtp_data.species)
         energies = self.mtp_data.species_coeffs[itypes]
 

--- a/tests/optimizers/test_lls.py
+++ b/tests/optimizers/test_lls.py
@@ -431,7 +431,7 @@ def test_mmtp_illconditioned(
     optimizer = LLSOptimizer(loss, optimized=optimized, minimized=minimized)
 
     # Verify the matrix is actually ill-conditioned before scaling.
-    optimizer.rank0_loss(mtp_data.parameters)
+    optimizer.rank0_basis(mtp_data.parameters)
     optimizer.rank0_gather_data()
     matrix = optimizer._calc_matrix()
     cond = np.linalg.cond(matrix)

--- a/tests/potentials/mmtp/test_engines.py
+++ b/tests/potentials/mmtp/test_engines.py
@@ -22,6 +22,12 @@ except ImportError:
     NumbaMagMTPEngine = None  # type: ignore[assignment,misc]
     _numba_available = False
 
+def _evaluate(engine: MagEngineBase, atoms, magmoms=None) -> dict:
+    if "train" in engine.mode:
+        return engine.jac(atoms, magmoms, mgrad=engine.mode == "train_mgrad")
+    return engine.efs(atoms, magmoms)
+
+
 _numba_mag_param = pytest.param(
     NumbaMagMTPEngine,
     marks=pytest.mark.skipif(not _numba_available, reason="numba not available"),
@@ -47,7 +53,7 @@ class TestCollinearMagmoms:
     def test_2d_all_zero_columns_accepted(self, mag_engine_and_atoms) -> None:
         engine, atoms = mag_engine_and_atoms
         magmoms_2d = np.zeros((len(atoms), 3))
-        result = engine.calculate(atoms, magmoms=magmoms_2d)
+        result = _evaluate(engine, atoms, magmoms=magmoms_2d)
         assert "energy" in result
 
     def test_2d_noncollinear_raises(self, mag_engine_and_atoms) -> None:
@@ -56,7 +62,7 @@ class TestCollinearMagmoms:
         magmoms_2d[:, 0] = 1.0
         magmoms_2d[:, 2] = 1.0
         with pytest.raises(ValueError, match="Non-collinear"):
-            engine.calculate(atoms, magmoms=magmoms_2d)
+            _evaluate(engine, atoms, magmoms=magmoms_2d)
 
 
 @pytest.mark.parametrize("level", [2, 4, 6, 8, 10])
@@ -97,8 +103,8 @@ def test_mmtp_energies_forces_stress(
     atoms.set_initial_magnetic_moments(atoms.get_magnetic_moments())
 
     # Calculate with both engines
-    result = engine.calculate(atoms)
-    ref_result = ref_engine.calculate(atoms)
+    result = _evaluate(engine, atoms)
+    ref_result = _evaluate(ref_engine, atoms)
 
     # Compare energies
     np.testing.assert_allclose(
@@ -162,17 +168,17 @@ def test_mgrad(
     atoms_ref = read_cfg(path / "mag.cfg", index=-1)
     atoms_ref.set_initial_magnetic_moments(atoms_ref.get_magnetic_moments())
 
-    mag_grad_ref = engine.calculate(atoms_ref)["mgrad"]
+    mag_grad_ref = _evaluate(engine, atoms_ref)["mgrad"]
 
     dx = 1e-6
 
     atoms = atoms_ref.copy()
     atoms.arrays["initial_magmoms"][0] += dx
-    ep = engine.calculate(atoms)["energy"]
+    ep = _evaluate(engine, atoms)["energy"]
 
     atoms = atoms_ref.copy()
     atoms.arrays["initial_magmoms"][0] -= dx
-    em = engine.calculate(atoms)["energy"]
+    em = _evaluate(engine, atoms)["energy"]
 
     t = +1.0 * (ep - em) / (2.0 * dx)
 
@@ -202,17 +208,17 @@ def test_forces(
     atoms_ref = read_cfg(path / "mag.cfg", index=-1)
     atoms_ref.set_initial_magnetic_moments(atoms_ref.get_magnetic_moments())
 
-    forces_ref = engine.calculate(atoms_ref)["forces"]
+    forces_ref = _evaluate(engine, atoms_ref)["forces"]
 
     dx = 1e-6
 
     atoms = atoms_ref.copy()
     atoms.positions[0, 0] += dx
-    ep = engine.calculate(atoms)["energy"]
+    ep = _evaluate(engine, atoms)["energy"]
 
     atoms = atoms_ref.copy()
     atoms.positions[0, 0] -= dx
-    em = engine.calculate(atoms)["energy"]
+    em = _evaluate(engine, atoms)["energy"]
 
     f = -1.0 * (ep - em) / (2.0 * dx)
 
@@ -243,7 +249,7 @@ def test_stress(
     magmoms = atoms_ref.get_magnetic_moments().copy()
     atoms_ref.set_initial_magnetic_moments(magmoms)
 
-    stress_ref = mtp.calculate(atoms_ref)["stress"]
+    stress_ref = _evaluate(mtp, atoms_ref)["stress"]
 
     stress = np.zeros((3, 3), dtype=float)
     eps = 1e-6
@@ -255,13 +261,13 @@ def test_stress(
         atoms = atoms_ref.copy()
         atoms.set_cell(cell @ x, scale_atoms=True)
         atoms.set_initial_magnetic_moments(magmoms)
-        eplus = mtp.calculate(atoms)["energy"]
+        eplus = _evaluate(mtp, atoms)["energy"]
 
         x[i, i] = 1.0 - eps
         atoms = atoms_ref.copy()
         atoms.set_cell(cell @ x, scale_atoms=True)
         atoms.set_initial_magnetic_moments(magmoms)
-        eminus = mtp.calculate(atoms)["energy"]
+        eminus = _evaluate(mtp, atoms)["energy"]
 
         stress[i, i] = (eplus - eminus) / (2.0 * eps * volume)
         x[i, i] = 1.0
@@ -271,13 +277,13 @@ def test_stress(
         atoms = atoms_ref.copy()
         atoms.set_cell(cell @ x, scale_atoms=True)
         atoms.set_initial_magnetic_moments(magmoms)
-        eplus = mtp.calculate(atoms)["energy"]
+        eplus = _evaluate(mtp, atoms)["energy"]
 
         x[i, j] = x[j, i] = -0.5 * eps
         atoms = atoms_ref.copy()
         atoms.set_cell(cell @ x, scale_atoms=True)
         atoms.set_initial_magnetic_moments(magmoms)
-        eminus = mtp.calculate(atoms)["energy"]
+        eminus = _evaluate(mtp, atoms)["energy"]
 
         stress[i, j] = stress[j, i] = (eplus - eminus) / (2 * eps * volume)
 
@@ -315,8 +321,8 @@ def test_basis_data(
     atoms = read_cfg(path / "mag.cfg", index=-1)
     atoms.set_initial_magnetic_moments(atoms.get_magnetic_moments())
 
-    ref.calculate(atoms)
-    mtp.calculate(atoms)
+    _evaluate(ref, atoms)
+    _evaluate(mtp, atoms)
 
     mbd = mtp.mbd
     mbd_ref = ref.mbd

--- a/tests/potentials/mmtp/test_jacobian.py
+++ b/tests/potentials/mmtp/test_jacobian.py
@@ -45,7 +45,7 @@ def test_jac_energy(
     """Test analytical energy Jacobian against finite differences for MMTP."""
     atoms = make_mag_atoms(engine, level, data_path)
 
-    atoms.get_potential_energy()
+    atoms.calc.compute_jacobian(atoms)
     jac_anl = atoms.calc.engine.jac_energy(atoms)
 
     dx = 1e-6
@@ -91,7 +91,7 @@ def test_jac_forces(
     """
     atoms = make_mag_atoms(engine, level, data_path)
 
-    atoms.get_potential_energy()
+    atoms.calc.compute_jacobian(atoms)
     jac_anl = atoms.calc.engine.jac_forces(atoms)
 
     dx = 1e-6

--- a/tests/potentials/mtp/test_engines.py
+++ b/tests/potentials/mtp/test_engines.py
@@ -27,6 +27,17 @@ except ImportError:
     JaxMTPEngine = None  # type: ignore[assignment,misc]
     _jax_available = False
 
+_NO_JAC = (JaxMTPEngine,) if _jax_available else ()
+
+
+def _evaluate(engine: EngineBase, atoms) -> dict:
+    if "train" in engine.mode:
+        if isinstance(engine, _NO_JAC):
+            pytest.skip("engine has no jacobian path")
+        return engine.jac(atoms)
+    return engine.efs(atoms)
+
+
 _numba_param = pytest.param(
     NumbaMTPEngine,
     marks=pytest.mark.skipif(not _numba_available, reason="numba not available"),
@@ -59,7 +70,7 @@ def test_molecules(
     mtp = engine(mtp_data, mode=mode)
     images = [read_cfg(path / "out.cfg", index=0)]
 
-    results_all = [mtp.calculate(atoms) for atoms in images]
+    results_all = [_evaluate(mtp, atoms) for atoms in images]
 
     energies_ref = np.array([_.get_potential_energy() for _ in images])
     energies = np.array([_["energy"] for _ in results_all]).reshape(-1)
@@ -91,7 +102,7 @@ def test_crystals(
     mtp = engine(mtp_data, mode=mode)
     images = [read_cfg(path / "out.cfg", index=-1)]
 
-    results_all = [mtp.calculate(atoms) for atoms in images]
+    results_all = [_evaluate(mtp, atoms) for atoms in images]
 
     energies_ref = np.array([_.get_potential_energy() for _ in images])
     energies = np.array([_["energy"] for _ in results_all]).reshape(-1)
@@ -126,17 +137,17 @@ def test_forces(
     mtp = engine(mtp_data)
     atoms_ref = read_cfg(path / "out.cfg", index=-1)
 
-    forces_ref = mtp.calculate(atoms_ref)["forces"]
+    forces_ref = _evaluate(mtp, atoms_ref)["forces"]
 
     dx = 1e-6
 
     atoms = atoms_ref.copy()
     atoms.positions[0, 0] += dx
-    ep = mtp.calculate(atoms)["energy"]
+    ep = _evaluate(mtp, atoms)["energy"]
 
     atoms = atoms_ref.copy()
     atoms.positions[0, 0] -= dx
-    em = mtp.calculate(atoms)["energy"]
+    em = _evaluate(mtp, atoms)["energy"]
 
     f = -1.0 * (ep - em) / (2.0 * dx)
 
@@ -169,7 +180,7 @@ def test_stress(
     mtp_data = read_mtp(path / "pot.mtp")
     mtp = engine(mtp_data)
     atoms_ref = read_cfg(path / "out.cfg", index=-1)
-    stress_ref = mtp.calculate(atoms_ref)["stress"]
+    stress_ref = _evaluate(mtp, atoms_ref)["stress"]
 
     stress = np.zeros((3, 3), dtype=float)
     eps = 1e-6
@@ -180,12 +191,12 @@ def test_stress(
         x[i, i] = 1.0 + eps
         atoms = atoms_ref.copy()
         atoms.set_cell(cell @ x, scale_atoms=True)
-        eplus = mtp.calculate(atoms)["energy"]
+        eplus = _evaluate(mtp, atoms)["energy"]
 
         x[i, i] = 1.0 - eps
         atoms = atoms_ref.copy()
         atoms.set_cell(cell @ x, scale_atoms=True)
-        eminus = mtp.calculate(atoms)["energy"]
+        eminus = _evaluate(mtp, atoms)["energy"]
 
         stress[i, i] = (eplus - eminus) / (2.0 * eps * volume)
         x[i, i] = 1.0
@@ -194,12 +205,12 @@ def test_stress(
         x[i, j] = x[j, i] = +0.5 * eps
         atoms = atoms_ref.copy()
         atoms.set_cell(cell @ x, scale_atoms=True)
-        eplus = mtp.calculate(atoms)["energy"]
+        eplus = _evaluate(mtp, atoms)["energy"]
 
         x[i, j] = x[j, i] = -0.5 * eps
         atoms = atoms_ref.copy()
         atoms.set_cell(cell @ x, scale_atoms=True)
-        eminus = mtp.calculate(atoms)["energy"]
+        eminus = _evaluate(mtp, atoms)["energy"]
 
         stress[i, j] = stress[j, i] = (eplus - eminus) / (2 * eps * volume)
 
@@ -229,8 +240,8 @@ def test_basis_data(
     images = [read_cfg(path / "out.cfg", index=-1)]
 
     for atoms in images:
-        ref.calculate(atoms)
-        mtp.calculate(atoms)
+        _evaluate(ref, atoms)
+        _evaluate(mtp, atoms)
 
         mbd = mtp.mbd
         mbd_ref = ref.mbd

--- a/tests/potentials/mtp/test_jacobian.py
+++ b/tests/potentials/mtp/test_jacobian.py
@@ -39,7 +39,7 @@ def test_jac_energy(
     """Test the Jacobian for the energy with respect to the parameters."""
     atoms = make_atoms(engine, level, data_path)
 
-    atoms.get_potential_energy()
+    atoms.calc.compute_jacobian(atoms)
     jac_anl = atoms.calc.engine.jac_energy(atoms)
 
     dx = 1e-6
@@ -82,7 +82,7 @@ def test_jac_forces(
     """Test the Jacobian for the forces with respect to the parameters."""
     atoms = make_atoms(engine, level, data_path)
 
-    atoms.get_potential_energy()
+    atoms.calc.compute_jacobian(atoms)
     jac_anl = atoms.calc.engine.jac_forces(atoms)
 
     dx = 1e-6
@@ -123,7 +123,7 @@ def test_jac_stress(
     """Test the Jacobian for the forces with respect to the parameters."""
     atoms = make_atoms(engine, level, data_path)
 
-    atoms.get_potential_energy()
+    atoms.calc.compute_jacobian(atoms)
     jac_anl = atoms.calc.engine.jac_stress(atoms)
 
     dx = 1e-6

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -1,0 +1,146 @@
+"""Tests for the MPI-parallel code paths in :mod:`motep.loss`.
+
+These tests exercise the multi-rank behaviour without launching ``mpirun``.
+A :class:`FakeComm` models a *buffered* point-to-point communicator: a
+"worker" rank pushes tagged messages into a shared store and the root rank
+later drains them. That is exactly the access pattern of
+:meth:`motep.loss.LossFunction.gather_data`, so it can be driven serially in
+a single test process.
+
+"""
+
+from collections import deque
+from types import SimpleNamespace
+
+from motep.loss import LossFunction
+
+_MISSING = object()
+
+
+class FakeComm:
+    """Buffered point-to-point communicator sharing one message store.
+
+    Two instances built with the same ``store`` (one per simulated rank)
+    exchange messages: :meth:`send` appends to the per-tag queue and
+    :meth:`recv` pops from it. Tags are unique per ``(image, message-kind)``
+    in ``gather_data``, so cross-rank ordering is irrelevant.
+    """
+
+    def __init__(self, rank: int, size: int, store: dict[int, deque]) -> None:
+        self.rank = rank
+        self.size = size
+        self._store = store
+
+    def send(self, obj: object, dest: int, tag: int = 0) -> None:
+        self._store.setdefault(tag, deque()).append(obj)
+
+    def recv(self, source: int = 0, tag: int = 0) -> object:
+        return self._store[tag].popleft()
+
+
+def _make_engine(mbd, rbd, *, jac_valid, mgrad_valid=_MISSING):
+    """Build a minimal engine stand-in with the attributes gather_data reads."""
+    engine = SimpleNamespace(mbd=mbd, rbd=rbd, _jac_valid=jac_valid)
+    if mgrad_valid is not _MISSING:
+        engine._mgrad_valid = mgrad_valid
+    return engine
+
+
+def _make_loss(rank, size, store, engines):
+    """Duck-typed LossFunction stand-in carrying only comm + images."""
+    images = [SimpleNamespace(calc=SimpleNamespace(engine=e)) for e in engines]
+    return SimpleNamespace(comm=FakeComm(rank, size, store), images=images)
+
+
+def _transfer(*, producer_engines, consumer_engines, size=2):
+    """Run gather_data producer-side then root-side over a shared store.
+
+    Returns the (mutated) consumer-side engines.
+    """
+    store: dict[int, deque] = {}
+    producer = _make_loss(rank=1, size=size, store=store, engines=producer_engines)
+    consumer = _make_loss(rank=0, size=size, store=store, engines=consumer_engines)
+    # Producer (worker) pushes its slice into the store...
+    LossFunction.gather_data(producer)
+    # ...then the root drains it, overwriting its placeholders.
+    LossFunction.gather_data(consumer)
+    return consumer.images
+
+
+def test_gather_data_transfers_basis_and_stale_flags() -> None:
+    """A stale (energy-only) worker result must land on root as stale."""
+    prod_mbd, prod_rbd = object(), object()
+    # image 0 -> root 0 (never transferred); image 1 -> root 1 (worker slice).
+    producer = [
+        _make_engine(None, None, jac_valid=False, mgrad_valid=False),
+        _make_engine(prod_mbd, prod_rbd, jac_valid=False, mgrad_valid=False),
+    ]
+    # Root's placeholder for image 1 is wrongly "valid" before the gather.
+    consumer = [
+        _make_engine(None, None, jac_valid=False, mgrad_valid=False),
+        _make_engine("stale", "stale", jac_valid=True, mgrad_valid=True),
+    ]
+
+    images = _transfer(producer_engines=producer, consumer_engines=consumer)
+    engine = images[1].calc.engine
+
+    assert engine.mbd is prod_mbd
+    assert engine.rbd is prod_rbd
+    assert engine._jac_valid is False
+    assert engine._mgrad_valid is False
+
+
+def test_gather_data_transfers_valid_flags() -> None:
+    """A full jac(mgrad=True) worker result round-trips as valid."""
+    prod_mbd, prod_rbd = object(), object()
+    producer = [
+        _make_engine(None, None, jac_valid=True, mgrad_valid=True),
+        _make_engine(prod_mbd, prod_rbd, jac_valid=True, mgrad_valid=True),
+    ]
+    consumer = [
+        _make_engine(None, None, jac_valid=False, mgrad_valid=False),
+        _make_engine("stale", "stale", jac_valid=False, mgrad_valid=False),
+    ]
+
+    images = _transfer(producer_engines=producer, consumer_engines=consumer)
+    engine = images[1].calc.engine
+
+    assert engine.mbd is prod_mbd
+    assert engine.rbd is prod_rbd
+    assert engine._jac_valid is True
+    assert engine._mgrad_valid is True
+
+
+def test_gather_data_nonmagnetic_engine_has_no_mgrad_flag() -> None:
+    """Non-magnetic engines lack ``_mgrad_valid``; it must not be invented."""
+    prod_mbd, prod_rbd = object(), object()
+    producer = [
+        _make_engine(None, None, jac_valid=True),
+        _make_engine(prod_mbd, prod_rbd, jac_valid=True),
+    ]
+    consumer = [
+        _make_engine(None, None, jac_valid=False),
+        _make_engine("stale", "stale", jac_valid=False),
+    ]
+
+    images = _transfer(producer_engines=producer, consumer_engines=consumer)
+    engine = images[1].calc.engine
+
+    assert engine.mbd is prod_mbd
+    assert engine.rbd is prod_rbd
+    assert engine._jac_valid is True
+    assert not hasattr(engine, "_mgrad_valid")
+
+
+def test_gather_data_size_one_is_noop() -> None:
+    """At size 1 every image is root-owned; nothing is sent or received."""
+    store: dict[int, deque] = {}
+    engines = [_make_engine("a", "b", jac_valid=True, mgrad_valid=True)]
+    loss = _make_loss(rank=0, size=1, store=store, engines=engines)
+
+    LossFunction.gather_data(loss)
+
+    assert store == {}
+    engine = loss.images[0].calc.engine
+    assert engine.mbd == "a"
+    assert engine._jac_valid is True

--- a/tests/upconvert/test_upconverter.py
+++ b/tests/upconvert/test_upconverter.py
@@ -23,6 +23,6 @@ def test_upconvert(src_level: int, dst_level: int, data_path: Path) -> None:
     src_mtp = NumbaMTPEngine(src_dat, mode="run")
     dst_mtp = NumbaMTPEngine(dst_dat, mode="run")
     atoms = read_cfg(src_path / "out.cfg")
-    src_energy = src_mtp.calculate(atoms)["energy"]
-    dst_energy = dst_mtp.calculate(atoms)["energy"]
+    src_energy = src_mtp.efs(atoms)["energy"]
+    dst_energy = dst_mtp.efs(atoms)["energy"]
     assert dst_energy == pytest.approx(src_energy)


### PR DESCRIPTION
This PR is related to #127 and applies very similar changes, but preserves the "mode" state of the engine. Effectively, what was previously determined by the mode is now separated out partly:

- The `static_geometry` argument controls whether position changes are allowed. Replaces the silently fixed positions in "train" mode.
- `efs()` and `jac()` replaces `calculate()` at the engine to flexibly allow calling an energy/forces/stress-only evaluation in "train" mode. `jac()` is not allowed in "run" mode.
- The mode now in principle only determines what to initialize, and if the Jacobian related methods are allowed.
- A benchmark script is added.