### PR TITLE
Cleanup: Refactor force and stress calculations to use tensordot for improved performance

### DIFF
--- a/motep/potentials/mmtp/cext/engine.py
+++ b/motep/potentials/mmtp/cext/engine.py
@@ -110,8 +110,8 @@ class CExtMagMTPEngine(MagEngineBase):
 
         moment_coeffs = mtp_data.moment_coeffs
 
-        forces = np.sum(moment_coeffs * self.mbd.dbdris.T, axis=-1).T * -1.0
-        stress = np.sum(moment_coeffs * self.mbd.dbdeps.T, axis=-1).T
+        forces = -np.tensordot(moment_coeffs, self.mbd.dbdris, axes=(0, 0))
+        stress = np.tensordot(moment_coeffs, self.mbd.dbdeps, axes=(0, 0))
         mgrad = _mmtp_cext.calc_mgrad_from_gradient(grad_mag_i, grad_mag_j, js)
 
         return energies, forces, stress, mgrad
@@ -143,8 +143,8 @@ class CExtMagMTPEngine(MagEngineBase):
 
         moment_coeffs = mtp_data.moment_coeffs
 
-        forces = np.sum(moment_coeffs * self.mbd.dbdris.T, axis=-1).T * -1.0
-        stress = np.sum(moment_coeffs * self.mbd.dbdeps.T, axis=-1).T
-        mgrad = np.sum(moment_coeffs * self.mbd.dbdmis.T, axis=-1).T
+        forces = -np.tensordot(moment_coeffs, self.mbd.dbdris, axes=(0, 0))
+        stress = np.tensordot(moment_coeffs, self.mbd.dbdeps, axes=(0, 0))
+        mgrad = np.tensordot(moment_coeffs, self.mbd.dbdmis, axes=(0, 0))
 
         return energies, forces, stress, mgrad

--- a/motep/potentials/mmtp/numba/engine.py
+++ b/motep/potentials/mmtp/numba/engine.py
@@ -166,8 +166,8 @@ class NumbaMagMTPEngine(MagEngineBase):
 
         moment_coeffs = mtp_data.moment_coeffs
 
-        forces = np.sum(moment_coeffs * self.mbd.dbdris.T, axis=-1).T * -1.0
-        stress = np.sum(moment_coeffs * self.mbd.dbdeps.T, axis=-1).T
+        forces = -np.tensordot(moment_coeffs, self.mbd.dbdris, axes=(0, 0))
+        stress = np.tensordot(moment_coeffs, self.mbd.dbdeps, axes=(0, 0))
         mgrad = _calc_mgrad_from_gradient(mgrad_i, mgrad_j, js)
 
         return energies, forces, stress, mgrad
@@ -222,9 +222,9 @@ class NumbaMagMTPEngine(MagEngineBase):
 
         moment_coeffs = mtp_data.moment_coeffs
 
-        forces = np.sum(moment_coeffs * self.mbd.dbdris.T, axis=-1).T * -1.0
-        mgrad = np.sum(moment_coeffs * self.mbd.dbdmis.T, axis=-1).T
-        stress = np.sum(moment_coeffs * self.mbd.dbdeps.T, axis=-1).T
+        forces = -np.tensordot(moment_coeffs, self.mbd.dbdris, axes=(0, 0))
+        mgrad = np.tensordot(moment_coeffs, self.mbd.dbdmis, axes=(0, 0))
+        stress = np.tensordot(moment_coeffs, self.mbd.dbdeps, axes=(0, 0))
 
         return energies, forces, stress, mgrad
 

--- a/motep/potentials/mtp/cext/engine.py
+++ b/motep/potentials/mtp/cext/engine.py
@@ -94,7 +94,7 @@ class CExtMTPEngine(EngineBase):
 
         moment_coeffs = mtp_data.moment_coeffs
 
-        forces = np.sum(moment_coeffs * self.mbd.dbdris.T, axis=-1).T * -1.0
-        stress = np.sum(moment_coeffs * self.mbd.dbdeps.T, axis=-1).T
+        forces = -np.tensordot(moment_coeffs, self.mbd.dbdris, axes=(0, 0))
+        stress = np.tensordot(moment_coeffs, self.mbd.dbdeps, axes=(0, 0))
 
         return energies, forces, stress

--- a/motep/potentials/mtp/numba/engine.py
+++ b/motep/potentials/mtp/numba/engine.py
@@ -106,8 +106,8 @@ class NumbaMTPEngine(EngineBase):
 
         moment_coeffs = mtp_data.moment_coeffs
 
-        forces = np.sum(moment_coeffs * self.mbd.dbdris.T, axis=-1).T * -1.0
-        stress = np.sum(moment_coeffs * self.mbd.dbdeps.T, axis=-1).T
+        forces = -np.tensordot(moment_coeffs, self.mbd.dbdris, axes=(0, 0))
+        stress = np.tensordot(moment_coeffs, self.mbd.dbdeps, axes=(0, 0))
 
         return energies, forces, stress
 

--- a/motep/potentials/mtp/numpy/engine.py
+++ b/motep/potentials/mtp/numpy/engine.py
@@ -100,7 +100,7 @@ class NumpyMTPEngine(EngineBase):
                 self.mbd.dgdcs[itype, :, :, :, j] += dgdcs[:, :, :, k]
             self.mbd.dsdcs[itype] += rs_i.T @ dgdcs
 
-        forces = np.sum(moment_coeffs * self.mbd.dbdris.T, axis=-1).T * -1.0
-        stress = np.sum(moment_coeffs * self.mbd.dbdeps.T, axis=-1).T
+        forces = -np.tensordot(moment_coeffs, self.mbd.dbdris, axes=(0, 0))
+        stress = np.tensordot(moment_coeffs, self.mbd.dbdeps, axes=(0, 0))
 
         return energies, forces, stress


### PR DESCRIPTION
This PR has a neglidible impact on overall performance, and is thereby mainly added for cleanliness. It replaces
```python
np.sum(coeffs * basis_data.T, axis=-1).T
```
with
```python
np.tensordot(coeffs, basis_data, axes=(0, 0))
```
which is much faster and avoids temporary allocations.