### PR TITLE
Improved performance for parameter Jacobian calculations

### DIFF
--- a/benchmarks/crossover.py
+++ b/benchmarks/crossover.py
@@ -1,44 +1,34 @@
-"""Locate the level where motep's parameter-Jacobian pass goes bandwidth bound.
+"""Time motep's parameter-Jacobian ("train") pass across MTP levels.
 
-The cext ``train`` engine builds, per atom, a ``moment_jac_rc`` scratch buffer
-of size ``n_basic * species * radial_funcs * radial_basis * n_neighbors * 3``
-doubles. Once this no longer fits in cache the kernel becomes memory-bandwidth
-bound and its per-level cost climbs steeply. This script sweeps levels and times
-the motep Jacobian pass (``calc.compute_jacobian``) against a reference to find
-that crossover.
+Sweeps a range of levels and times the motep Jacobian pass
+(``calc.compute_jacobian``) against a reference, to see how the per-level cost
+scales -- e.g. to spot where the training kernel's per-work cost starts to climb.
 
 Two references are supported:
 
 * ``--mlp-cfg FILE``: times the real ``mlp train`` CLI and motep on the same
   configurations. ``mlp train`` is timed by two-point subtraction -- run at two
   iteration limits and divide the time difference by the iteration delta -- so
-  all fixed startup cost cancels, leaving milliseconds per BFGS iteration. Both
-  the MLIP-2 (``--max-iter``, ``--trained-pot-name``) and MLIP-3 / spin-MLIP
-  (``--iteration_limit``, ``--save_to``) dialects are supported and auto-detected
-  from ``mlp help train``; override with ``--mlp-flavor``. The trained potential
-  is always written to a temp file (MLIP-3 ``--save_to`` overwrites otherwise).
-
-  One BFGS iteration includes a line search, so it spans *several* EFS+gradient
-  evaluations over the set -- not one -- whereas the motep column times a single
-  Jacobian pass. Pass ``--mlp-evals-per-iter N`` to divide the mlp time by ``N``
-  and compare per-evaluation; the column is then labelled ``mlp/eval``. Note the
-  two-point subtraction cancels fixed cost but does not normalise the
-  line-search count, so ``N`` is an estimate of its average over iterations
-  ``K1..K2``.
+  fixed startup cost cancels, leaving milliseconds per BFGS iteration. The MLIP-2
+  and MLIP-3 CLI dialects are auto-detected from ``mlp help train``; override
+  with ``--mlp-flavor``. One BFGS iteration includes a line search (several
+  EFS+gradient sweeps), so pass ``--mlp-evals-per-iter N`` to divide by that
+  count and compare per-evaluation.
 
 * no ``--mlp-cfg``: uses motep ``run`` mode (EFS only, no parameter Jacobian) as
   the reference.
 
-The ``norm`` column is the motep Jacobian time per atom-image per unit of
-``n_basic``. It is ~flat while the buffer is cache resident and rises once the
-kernel goes bandwidth bound; the level where it starts climbing is the crossover.
+Columns:
+
+* ``scratch/atom`` -- per-atom size of the fused radial-coeff Jacobian working
+  set (``species * radial_funcs * radial_basis * n_neighbors * 3`` doubles); a
+  proxy for how much hot scratch the kernel touches.
+* ``norm(us)`` -- Jacobian time per atom-image per unit of ``n_basic``; roughly
+  flat while the kernel stays compute/cache bound and rises if it does not.
 
 Run::
 
-    python -m benchmarks.crossover --mlp-cfg /path/to/subset.cfg \
-        --levels 8 10 12 14 16 18 20
-
-Prepare a small subset cfg (keeps the sweep fast).
+    python -m benchmarks.crossover --levels 8 10 12 14 16 18 20
 """
 
 import argparse
@@ -68,12 +58,12 @@ def _time(fn, n_repeat: int) -> float:
     return best * 1000.0
 
 
-def _moment_jac_rc_bytes(mtp_data, n_neighbors: int) -> int:
-    n_basic = len(mtp_data.alpha_index_basic)
+def _tmp_dgdcs_bytes(mtp_data, n_neighbors: int) -> int:
+    """Per-atom size of the fused radial-coeff Jacobian scratch (``tmp_dgdcs``)."""
     rfc = mtp_data.radial_funcs_count
     rbs = mtp_data.radial_basis.size
     spc = mtp_data.species_count
-    return n_basic * spc * rfc * rbs * n_neighbors * 3 * 8
+    return spc * rfc * rbs * n_neighbors * 3 * 8
 
 
 def _make_calc(pot_path: pathlib.Path, species: list[int], *, mode: str) -> MTP:
@@ -227,7 +217,7 @@ def main(
     ref_desc = f"{ref_label} ({mlp_flavor})" if mlp_cfg is not None else ref_label
     print(f"=== {len(images)} configs x {natoms} atoms | reference = {ref_desc} ===")
     header = (
-        f"{'lvl':>3} {'n_basic':>7} {'mjac_rc/atom':>12} "
+        f"{'lvl':>3} {'n_basic':>7} {'scratch/atom':>12} "
         f"{'motep(ms)':>10} {ref_label:>10} {'motep/ref':>10} {'norm(us)':>9}"
     )
     print(header)
@@ -246,7 +236,7 @@ def main(
         train_calc = _make_calc(pot_path, species, mode="train")
         train_calc.compute_jacobian(images[-1])  # warm up
         nn = train_calc.engine._neighbors.shape[1]
-        mjrc_kb = _moment_jac_rc_bytes(mtp_data, nn) / 1024.0
+        scratch_kb = _tmp_dgdcs_bytes(mtp_data, nn) / 1024.0
 
         def motep_pass(c=train_calc):
             for a in images:
@@ -276,7 +266,7 @@ def main(
             t_ref = _time(run_pass, n_repeat)
 
         print(
-            f"{level:>3} {n_basic:>7} {mjrc_kb:>10.1f}K "
+            f"{level:>3} {n_basic:>7} {scratch_kb:>10.1f}K "
             f"{t_motep:>10.1f} {t_ref:>10.1f} {t_motep / t_ref:>10.2f} {norm_us:>9.3f}",
             flush=True,
         )

--- a/motep/potentials/mmtp/cext/mmtp_cext.c
+++ b/motep/potentials/mmtp/cext/mmtp_cext.c
@@ -348,16 +348,8 @@ void calc_mag_train(
             moment_values,
             moment_jac_rs);
 
-        double *moment_jac_cs = (double *)calloc(n_basic * species_count * radial_funcs_count * nrb, sizeof(double));
-        double *moment_jac_rc = (double *)calloc(n_basic * species_count * radial_funcs_count * nrb * n_neighbors * 3, sizeof(double));
-
-        calc_basic_moments_jac_radial_coeffs(
-            n_neighbors, r_abs, r_unit, basis, dbdrs,
-            alpha_index_basic, n_basic,
-            species_count, jtype_i,
-            radial_funcs_count, nrb,
-            moment_jac_cs, moment_jac_rc);
-
+        /* Contract + backprop first so the fused radial-coeff Jacobian below can
+         * fold dedmb in on the fly (see mtp cext calc_train for the rationale). */
         contract_moments_forward(moment_values, alpha_index_times, n_times);
 
         contract_moment_jacobians_forward(moment_values, moment_jac_rs, alpha_index_times, n_times, n_neighbors);
@@ -377,6 +369,17 @@ void calc_mag_train(
             dedmb,
             dgdmb);
 
+        /* Only moment_jac_cs is materialized; moment_jac_rc (up to 16 MB/atom) is
+         * skipped by passing NULL and folded in by accumulate_dgdcs_dsdcs_fused. */
+        double *moment_jac_cs = (double *)calloc(n_basic * species_count * radial_funcs_count * nrb, sizeof(double));
+
+        calc_basic_moments_jac_radial_coeffs(
+            n_neighbors, r_abs, r_unit, basis, dbdrs,
+            alpha_index_basic, n_basic,
+            species_count, jtype_i,
+            radial_funcs_count, nrb,
+            moment_jac_cs, NULL);
+
         accumulate_mbd_dvdcs(
             i,
             itype,
@@ -389,26 +392,30 @@ void calc_mag_train(
             dedmb,
             mbd_dvdcs);
 
-        accumulate_mbd_dgdcs_dsdcs(
+        accumulate_dgdcs_dsdcs_fused(
             i,
             itype,
             n_atoms,
             n_neighbors,
             js_i,
             rs_i,
+            r_abs,
+            r_unit,
+            basis,
+            dbdrs,
+            alpha_index_basic,
             n_basic,
             species_count,
+            jtype_i,
             radial_funcs_count,
             nrb,
             moment_jac_cs,
-            moment_jac_rc,
             dedmb,
             dgdmb,
             mbd_dgdcs,
             mbd_dsdcs);
 
         free(moment_jac_cs);
-        free(moment_jac_rc);
         free(dedmb);
         free(dgdmb);
 
@@ -590,18 +597,8 @@ void calc_mag_train_mgrad(
             moment_jac_mis,
             moment_jac_mjs);
 
-        double *moment_jac_cs = (double *)calloc(n_basic * species_count * radial_funcs_count * nrb, sizeof(double));
-        double *moment_jac_rc = (double *)calloc(n_basic * species_count * radial_funcs_count * nrb * n_neighbors * 3, sizeof(double));
-        double *moment_jac_mic = (double *)calloc(n_basic * species_count * radial_funcs_count * nrb * n_neighbors, sizeof(double));
-        double *moment_jac_mjc = (double *)calloc(n_basic * species_count * radial_funcs_count * nrb * n_neighbors, sizeof(double));
-
-        calc_mag_basic_moments_jac_radial_coeffs(
-            n_neighbors, r_abs, r_unit, basis, dbdrs, dbdmis, dbdmjs,
-            alpha_index_basic, n_basic,
-            species_count, jtype_i,
-            radial_funcs_count, nrb,
-            moment_jac_cs, moment_jac_rc, moment_jac_mic, moment_jac_mjc);
-
+        /* Contract + backprop first so the fused radial-coeff Jacobians below can
+         * fold dedmb / dgm{i,j}dmb in on the fly. */
         contract_moments_forward(moment_values, alpha_index_times, n_times);
 
         contract_moment_jacobians_forward(moment_values, moment_jac_rs, alpha_index_times, n_times, n_neighbors);
@@ -630,6 +627,18 @@ void calc_mag_train_mgrad(
             dgmidmb,
             dgmjdmb);
 
+        /* Only moment_jac_cs is materialized; the large per-neighbor buffers
+         * moment_jac_rc/mic/mjc are skipped (NULL) and folded in by the fused
+         * kernels below. */
+        double *moment_jac_cs = (double *)calloc(n_basic * species_count * radial_funcs_count * nrb, sizeof(double));
+
+        calc_mag_basic_moments_jac_radial_coeffs(
+            n_neighbors, r_abs, r_unit, basis, dbdrs, dbdmis, dbdmjs,
+            alpha_index_basic, n_basic,
+            species_count, jtype_i,
+            radial_funcs_count, nrb,
+            moment_jac_cs, NULL, NULL, NULL);
+
         accumulate_mbd_dvdcs(
             i,
             itype,
@@ -642,46 +651,51 @@ void calc_mag_train_mgrad(
             dedmb,
             mbd_dvdcs);
 
-        accumulate_mbd_dgdcs_dsdcs(
+        accumulate_dgdcs_dsdcs_fused(
             i,
             itype,
             n_atoms,
             n_neighbors,
             js_i,
             rs_i,
+            r_abs,
+            r_unit,
+            basis,
+            dbdrs,
+            alpha_index_basic,
             n_basic,
             species_count,
+            jtype_i,
             radial_funcs_count,
             nrb,
             moment_jac_cs,
-            moment_jac_rc,
             dedmb,
             dgdmb,
             mbd_dgdcs,
             mbd_dsdcs);
 
-        accumulate_mbd_dgmdcs(
+        accumulate_dgmdcs_fused(
             i,
             itype,
             n_atoms,
             n_neighbors,
             js_i,
+            r_unit,
+            dbdmis,
+            dbdmjs,
+            alpha_index_basic,
             n_basic,
             species_count,
+            jtype_i,
             radial_funcs_count,
             nrb,
             moment_jac_cs,
-            moment_jac_mic,
-            moment_jac_mjc,
             dedmb,
             dgmidmb,
             dgmjdmb,
             mbd_dgmdcs);
 
         free(moment_jac_cs);
-        free(moment_jac_rc);
-        free(moment_jac_mic);
-        free(moment_jac_mjc);
         free(dedmb);
         free(dgdmb);
         free(dgmidmb);

--- a/motep/potentials/mmtp/cext/mmtp_cext_kernels.h
+++ b/motep/potentials/mmtp/cext/mmtp_cext_kernels.h
@@ -457,64 +457,130 @@ static inline void accumulate_mbd_dbdmis(
 }
 
 /* ==========================================================================
- * Helper: Accumulate mbd.dgmdcs for train_mgrad
+ * Accumulate mbd.dgmdcs — FUSED magnetic radial-coeff Jacobian.
+ *
+ * Replaces the two-pass scheme that materialized the large per-neighbor buffers
+ * moment_jac_mic / moment_jac_mjc (each ~n_basic*species*rfc*nrb*n_neighbors)
+ * and contracted them against dedmb. Here we recompute drb_dm{i,j}*angular
+ * exactly as calc_mag_basic_moments_jac_radial_coeffs did and fold dedmb in on
+ * the fly (Term A), accumulating into cache-resident tmp buffers; the kept small
+ * moment_jac_cs is contracted against dgm{i,j}dmb as before (Term B); then a
+ * single scatter writes mbd_dgmdcs. Numerically equal to the old dense scheme.
  * ========================================================================== */
-static inline void accumulate_mbd_dgmdcs(
+static inline void accumulate_dgmdcs_fused(
     int i,
     int itype,
     int n_atoms,
     int n_neighbors,
     const int *js_i,
+    const double *r_unit,
+    const double *drb_dmis,
+    const double *drb_dmjs,
+    const int *alpha_index_basic,
     int n_basic,
     int species_count,
+    const int *jtypes,
     int radial_funcs_count,
-    int radial_basis_size,
+    int nrb,
     const double *moment_jac_cs,
-    const double *moment_jac_mic,
-    const double *moment_jac_mjc,
     const double *dedmb,
     const double *dgmidmb,
     const double *dgmjdmb,
     double *mbd_dgmdcs)
 {
     int rfc = radial_funcs_count;
-    int rbs = radial_basis_size;
 
+    int tmp_size = species_count * rfc * nrb * n_neighbors;
+    double *tmp_i = (double *)calloc(tmp_size, sizeof(double));
+    double *tmp_j = (double *)calloc(tmp_size, sizeof(double));
+
+    /* Term A: (drb_dm{i,j} * angular) * dedmb[i_aib] -> tmp, live (jtype[k], mu). */
+    for (int i_aib = 0; i_aib < n_basic; i_aib++)
+    {
+        double v1 = dedmb[i_aib];
+        if (v1 == 0.0)
+            continue;
+
+        int mu = alpha_index_basic[i_aib * 4 + 0];
+        int xpow = alpha_index_basic[i_aib * 4 + 1];
+        int ypow = alpha_index_basic[i_aib * 4 + 2];
+        int zpow = alpha_index_basic[i_aib * 4 + 3];
+
+        for (int k = 0; k < n_neighbors; k++)
+        {
+            int jtype = jtypes[k];
+
+            double rx_pow = 1.0, ry_pow = 1.0, rz_pow = 1.0;
+            for (int p = 0; p < xpow; p++)
+                rx_pow *= r_unit[k * 3 + 0];
+            for (int p = 0; p < ypow; p++)
+                ry_pow *= r_unit[k * 3 + 1];
+            for (int p = 0; p < zpow; p++)
+                rz_pow *= r_unit[k * 3 + 2];
+
+            double angular = rx_pow * ry_pow * rz_pow;
+
+            for (int i_rb = 0; i_rb < nrb; i_rb++)
+            {
+                int base = (((jtype * rfc + mu) * nrb + i_rb) * n_neighbors + k);
+                tmp_i[base] += drb_dmis[i_rb * n_neighbors + k] * angular * v1;
+                tmp_j[base] += drb_dmjs[i_rb * n_neighbors + k] * angular * v1;
+            }
+        }
+    }
+
+    /* Term B: moment_jac_cs * dgm{i,j}dmb -> tmp (over the cs nonzeros). */
     for (int iamc = 0; iamc < n_basic; iamc++)
     {
-        double v1 = dedmb[iamc];
-
         for (int ispc = 0; ispc < species_count; ispc++)
         {
             for (int irf = 0; irf < rfc; irf++)
             {
-                for (int irb = 0; irb < rbs; irb++)
+                for (int irb = 0; irb < nrb; irb++)
                 {
-                    int idx_cs = ((iamc * species_count + ispc) * rfc + irf) * rbs + irb;
+                    int idx_cs = ((iamc * species_count + ispc) * rfc + irf) * nrb + irb;
                     double v3 = moment_jac_cs[idx_cs];
 
-                    if (v1 == 0.0 && v3 == 0.0)
+                    if (v3 == 0.0)
                         continue;
 
-                    int base_mic = (((iamc * species_count + ispc) * rfc + irf) * rbs + irb) * n_neighbors;
-                    int base_atom = ((((itype * species_count + ispc) * rfc + irf) * rbs + irb) * n_atoms);
+                    int base_tmp = ((ispc * rfc + irf) * nrb + irb) * n_neighbors;
 
                     for (int k = 0; k < n_neighbors; k++)
                     {
-                        int j = js_i[k];
-                        double vmi = moment_jac_mic[base_mic + k] * v1 + v3 * dgmidmb[iamc * n_neighbors + k];
-                        double vmj = moment_jac_mjc[base_mic + k] * v1 + v3 * dgmjdmb[iamc * n_neighbors + k];
-
-                        mbd_dgmdcs[base_atom + i] += vmi;
-                        if (j >= 0 && j < n_atoms)
-                        {
-                            mbd_dgmdcs[base_atom + j] += vmj;
-                        }
+                        tmp_i[base_tmp + k] += v3 * dgmidmb[iamc * n_neighbors + k];
+                        tmp_j[base_tmp + k] += v3 * dgmjdmb[iamc * n_neighbors + k];
                     }
                 }
             }
         }
     }
+
+    /* Scatter tmp -> mbd_dgmdcs (self atom i from tmp_i, neighbor j from tmp_j). */
+    for (int ispc = 0; ispc < species_count; ispc++)
+    {
+        for (int irf = 0; irf < rfc; irf++)
+        {
+            for (int irb = 0; irb < nrb; irb++)
+            {
+                int base_tmp = ((ispc * rfc + irf) * nrb + irb) * n_neighbors;
+                int base_atom = ((((itype * species_count + ispc) * rfc + irf) * nrb + irb) * n_atoms);
+
+                for (int k = 0; k < n_neighbors; k++)
+                {
+                    int j = js_i[k];
+                    mbd_dgmdcs[base_atom + i] += tmp_i[base_tmp + k];
+                    if (j >= 0 && j < n_atoms)
+                    {
+                        mbd_dgmdcs[base_atom + j] += tmp_j[base_tmp + k];
+                    }
+                }
+            }
+        }
+    }
+
+    free(tmp_i);
+    free(tmp_j);
 }
 
 /* ==========================================================================
@@ -573,13 +639,23 @@ static inline void calc_mag_basic_moments_jac_radial_coeffs(
                 int idx_cs = ((i_aib * species_count + jtype) * rfc + mu) * nrb + i_rb;
                 moment_jac_cs[idx_cs] += rb_val * angular;
 
-                int idx_mic = ((i_aib * species_count + jtype) * rfc + mu) * nrb * n_neighbors + i_rb * n_neighbors + k;
-                moment_jac_mic[idx_mic] += drb_dmi * angular;
+                /* rc/mic/mjc are optional: when NULL (fused path) the caller folds
+                 * these derivatives directly into tmp buffers via
+                 * accumulate_dgdcs_dsdcs_fused / accumulate_dgmdcs_fused, so the
+                 * large per-neighbor scratch buffers are never built. */
+                if (moment_jac_mic)
+                {
+                    int idx_mic = ((i_aib * species_count + jtype) * rfc + mu) * nrb * n_neighbors + i_rb * n_neighbors + k;
+                    moment_jac_mic[idx_mic] += drb_dmi * angular;
+                }
 
-                int idx_mjc = ((i_aib * species_count + jtype) * rfc + mu) * nrb * n_neighbors + i_rb * n_neighbors + k;
-                moment_jac_mjc[idx_mjc] += drb_dmj * angular;
+                if (moment_jac_mjc)
+                {
+                    int idx_mjc = ((i_aib * species_count + jtype) * rfc + mu) * nrb * n_neighbors + i_rb * n_neighbors + k;
+                    moment_jac_mjc[idx_mjc] += drb_dmj * angular;
+                }
 
-                if (r_abs[k] > 1e-10)
+                if (moment_jac_rc && r_abs[k] > 1e-10)
                 {
                     double der0 = r_unit[k * 3 + 0] * angular * (rb_der - xyzpow * rb_val / r_abs[k]);
                     double der1 = r_unit[k * 3 + 1] * angular * (rb_der - xyzpow * rb_val / r_abs[k]);

--- a/motep/potentials/mtp/cext/mtp_cext.c
+++ b/motep/potentials/mtp/cext/mtp_cext.c
@@ -284,19 +284,6 @@ void calc_train(
                            m, m_jac);
 
         /* ====================================================================
-         * Step 5b: Compute jacobians of basic moments w.r.t. radial coefficients
-         * ==================================================================== */
-        double *moment_jac_cs = (double *)calloc(n_basic * species_count * radial_funcs_count * rbs, sizeof(double));
-        double *moment_jac_rc = (double *)calloc(n_basic * species_count * radial_funcs_count * rbs * n_neighbors * 3, sizeof(double));
-
-        calc_basic_moments_jac_radial_coeffs(
-            n_neighbors, r_abs, r_unit, radial_basis, drb_drs,
-            alpha_index_basic, n_basic,
-            species_count, jtype_i,
-            radial_funcs_count, rbs,
-            moment_jac_cs, moment_jac_rc);
-
-        /* ====================================================================
          * Step 6: Contract moments through alpha_index_times
          * ==================================================================== */
         /* Contract moment values */
@@ -307,6 +294,8 @@ void calc_train(
 
         /* ====================================================================
          * Step 6a: Compute dedmb and dgdmb (backprop through moment contractions)
+         * Reordered before the radial-coeff Jacobian so the fused kernel below
+         * can fold dedmb in on the fly (dedmb does not depend on moment_jac_rc).
          * ==================================================================== */
         double *dedmb = (double *)calloc(alpha_moments_count, sizeof(double));
         double *dgdmb = (double *)calloc(alpha_moments_count * n_neighbors * 3, sizeof(double));
@@ -324,6 +313,22 @@ void calc_train(
             dgdmb);
 
         /* ====================================================================
+         * Step 5b: Jacobian of basic moments w.r.t. radial coefficients.
+         * Only moment_jac_cs is materialized; the large per-neighbor buffer
+         * moment_jac_rc (up to 16 MB/atom) is skipped by passing NULL — the
+         * fused kernel in Step 6c recomputes those derivatives and folds dedmb
+         * in directly, so the 16 MB scratch is never streamed through RAM.
+         * ==================================================================== */
+        double *moment_jac_cs = (double *)calloc(n_basic * species_count * radial_funcs_count * rbs, sizeof(double));
+
+        calc_basic_moments_jac_radial_coeffs(
+            n_neighbors, r_abs, r_unit, radial_basis, drb_drs,
+            alpha_index_basic, n_basic,
+            species_count, jtype_i,
+            radial_funcs_count, rbs,
+            moment_jac_cs, NULL);
+
+        /* ====================================================================
          * Step 6b: Accumulate dvdcs from basic moment jacobians
          * ==================================================================== */
         accumulate_mbd_dvdcs(
@@ -339,28 +344,32 @@ void calc_train(
             mbd->dvdcs);
 
         /* ====================================================================
-         * Step 6c: Accumulate dgdcs from basic moment jacobians
+         * Step 6c: Accumulate dgdcs/dsdcs (fused radial-coeff Jacobian)
          * ==================================================================== */
-        accumulate_mbd_dgdcs_dsdcs(
+        accumulate_dgdcs_dsdcs_fused(
             i,
             itype,
             n_atoms,
             n_neighbors,
             js_i,
             rs_i,
+            r_abs,
+            r_unit,
+            radial_basis,
+            drb_drs,
+            alpha_index_basic,
             n_basic,
             species_count,
+            jtype_i,
             radial_funcs_count,
             rbs,
             moment_jac_cs,
-            moment_jac_rc,
             dedmb,
             dgdmb,
             mbd->dgdcs,
             mbd->dsdcs);
 
         free(moment_jac_cs);
-        free(moment_jac_rc);
         free(dedmb);
         free(dgdmb);
 

--- a/motep/potentials/mtp/cext/mtp_cext_kernels.h
+++ b/motep/potentials/mtp/cext/mtp_cext_kernels.h
@@ -406,12 +406,10 @@ static inline void compute_dedmb_dgdmb(
  * Accumulate dgdcs/dsdcs — FUSED radial-coeff Jacobian.
  *
  * Replaces the old two-pass scheme (materialize the 16 MB/atom `moment_jac_rc`
- * then contract it against `dedmb`). Instead we recompute each per-neighbor
- * radial-coeff derivative `der0/der1/der2` exactly as
  * `calc_basic_moments_jac_radial_coeffs` did and immediately fold in
- * `dedmb[i_aib]`, accumulating straight into the cache-resident `tmp_dgdcs`
- * (~80 KB). Only the live `(jtype[k], mu)` slot is touched, so the old dense
- * consumer's `species_count * radial_funcs_count` wasted zero-reads vanish too.
+ * `dedmb[i_aib]`, accumulating straight into the per-atom scratch `tmp_dgdcs`
+ * (size: `species_count * radial_funcs_count * radial_basis_size * n_neighbors * 3` doubles). Only the live
+ * `(jtype[k], mu)` slot is touched, so the old dense
  *
  * Loops 2 (moment_jac_cs * dgdmb) and 3 (neighbor scatter into dgdcs/dsdcs) are
  * unchanged from the previous consumer — neither ever touched moment_jac_rc.

--- a/motep/potentials/mtp/cext/mtp_cext_kernels.h
+++ b/motep/potentials/mtp/cext/mtp_cext_kernels.h
@@ -232,7 +232,10 @@ static inline void calc_basic_moments_jac_radial_coeffs(
                 int idx_cs = ((i_aib * species_count + jtype) * rfc + mu) * rbs + i_rb;
                 moment_jac_cs[idx_cs] += rb_val * angular;
 
-                if (r_abs[k] > 1e-10)
+                /* moment_jac_rc is optional: when NULL (fused path) the caller
+                 * folds these derivatives directly into tmp_dgdcs via
+                 * accumulate_dgdcs_dsdcs_fused, so the 16 MB buffer is never built. */
+                if (moment_jac_rc && r_abs[k] > 1e-10)
                 {
                     double rb_der = rb_derivs[i_rb * n_neighbors + k];
 
@@ -400,21 +403,37 @@ static inline void compute_dedmb_dgdmb(
 }
 
 /* ==========================================================================
- * Accumulate dgdcs from moment_jac_cs/moment_jac_rc and dedmb/dgdmb
+ * Accumulate dgdcs/dsdcs — FUSED radial-coeff Jacobian.
+ *
+ * Replaces the old two-pass scheme (materialize the 16 MB/atom `moment_jac_rc`
+ * then contract it against `dedmb`). Instead we recompute each per-neighbor
+ * radial-coeff derivative `der0/der1/der2` exactly as
+ * `calc_basic_moments_jac_radial_coeffs` did and immediately fold in
+ * `dedmb[i_aib]`, accumulating straight into the cache-resident `tmp_dgdcs`
+ * (~80 KB). Only the live `(jtype[k], mu)` slot is touched, so the old dense
+ * consumer's `species_count * radial_funcs_count` wasted zero-reads vanish too.
+ *
+ * Loops 2 (moment_jac_cs * dgdmb) and 3 (neighbor scatter into dgdcs/dsdcs) are
+ * unchanged from the previous consumer — neither ever touched moment_jac_rc.
  * ========================================================================== */
-static inline void accumulate_mbd_dgdcs_dsdcs(
+static inline void accumulate_dgdcs_dsdcs_fused(
     int i,
     int itype,
     int n_atoms,
     int n_neighbors,
     const int *js_i,
     const double *rs_i,
+    const double *r_abs,
+    const double *r_unit,
+    const double *rb_vals,
+    const double *rb_derivs,
+    const int *alpha_index_basic,
     int n_basic,
     int species_count,
+    const int *jtypes,
     int radial_funcs_count,
     int radial_basis_size,
     const double *moment_jac_cs,
-    const double *moment_jac_rc,
     const double *dedmb,
     const double *dgdmb,
     double *dgdcs,
@@ -426,28 +445,72 @@ static inline void accumulate_mbd_dgdcs_dsdcs(
     int tmp_size = species_count * rfc * rbs * n_neighbors * 3;
     double *tmp_dgdcs = (double *)calloc(tmp_size, sizeof(double));
 
-    for (int iamc = 0; iamc < n_basic; iamc++)
+    /* Loop 1 (fused + sparse): der{0,1,2} * dedmb[i_aib] -> tmp_dgdcs.
+     * Mirrors calc_basic_moments_jac_radial_coeffs' derivative block. */
+    for (int i_aib = 0; i_aib < n_basic; i_aib++)
     {
-        double v1 = dedmb[iamc];
+        int mu = alpha_index_basic[i_aib * 4 + 0];
+        int xpow = alpha_index_basic[i_aib * 4 + 1];
+        int ypow = alpha_index_basic[i_aib * 4 + 2];
+        int zpow = alpha_index_basic[i_aib * 4 + 3];
+        int xyzpow = xpow + ypow + zpow;
+        double v1 = dedmb[i_aib];
 
-        for (int ispc = 0; ispc < species_count; ispc++)
+        for (int k = 0; k < n_neighbors; k++)
         {
-            for (int irf = 0; irf < rfc; irf++)
-            {
-                for (int irb = 0; irb < rbs; irb++)
-                {
-                    int base_tmp = (((ispc * rfc + irf) * rbs + irb) * n_neighbors) * 3;
-                    int base_rc = ((((iamc * species_count + ispc) * rfc + irf) * rbs + irb) * n_neighbors) * 3;
+            if (r_abs[k] <= 1e-10)
+                continue;
 
-                    for (int j = 0; j < n_neighbors; j++)
-                    {
-                        for (int ixyz = 0; ixyz < 3; ixyz++)
-                        {
-                            tmp_dgdcs[base_tmp + j * 3 + ixyz] +=
-                                moment_jac_rc[base_rc + j * 3 + ixyz] * v1;
-                        }
-                    }
+            int jtype = jtypes[k];
+
+            double rx_pow = 1.0, ry_pow = 1.0, rz_pow = 1.0;
+            for (int p = 0; p < xpow; p++)
+                rx_pow *= r_unit[k * 3 + 0];
+            for (int p = 0; p < ypow; p++)
+                ry_pow *= r_unit[k * 3 + 1];
+            for (int p = 0; p < zpow; p++)
+                rz_pow *= r_unit[k * 3 + 2];
+
+            double angular = rx_pow * ry_pow * rz_pow;
+
+            for (int i_rb = 0; i_rb < rbs; i_rb++)
+            {
+                double rb_val = rb_vals[i_rb * n_neighbors + k];
+                double rb_der = rb_derivs[i_rb * n_neighbors + k];
+
+                double der0 = r_unit[k * 3 + 0] * angular *
+                              (rb_der - xyzpow * rb_val / r_abs[k]);
+                double der1 = r_unit[k * 3 + 1] * angular *
+                              (rb_der - xyzpow * rb_val / r_abs[k]);
+                double der2 = r_unit[k * 3 + 2] * angular *
+                              (rb_der - xyzpow * rb_val / r_abs[k]);
+
+                if (xpow > 0)
+                {
+                    double rx_prev = 1.0;
+                    for (int p = 0; p < xpow - 1; p++)
+                        rx_prev *= r_unit[k * 3 + 0];
+                    der0 += rb_val * xpow * rx_prev * ry_pow * rz_pow / r_abs[k];
                 }
+                if (ypow > 0)
+                {
+                    double ry_prev = 1.0;
+                    for (int p = 0; p < ypow - 1; p++)
+                        ry_prev *= r_unit[k * 3 + 1];
+                    der1 += rb_val * rx_pow * ypow * ry_prev * rz_pow / r_abs[k];
+                }
+                if (zpow > 0)
+                {
+                    double rz_prev = 1.0;
+                    for (int p = 0; p < zpow - 1; p++)
+                        rz_prev *= r_unit[k * 3 + 2];
+                    der2 += rb_val * rx_pow * ry_pow * zpow * rz_prev / r_abs[k];
+                }
+
+                int base_tmp = (((jtype * rfc + mu) * rbs + i_rb) * n_neighbors + k) * 3;
+                tmp_dgdcs[base_tmp + 0] += der0 * v1;
+                tmp_dgdcs[base_tmp + 1] += der1 * v1;
+                tmp_dgdcs[base_tmp + 2] += der2 * v1;
             }
         }
     }


### PR DESCRIPTION
This PR refactors the radial-coeff Jacobian calculations in the cext engine to skip temporary array allocation (`moment_jac_rc`) by using a fused kernel and directly computing/accumulating into tmp_dgdcs, reducing memory usage and improving performance by eliminating the large temporary buffer.

On an M4 chip, this increases speed of the "train" pass by ~1.2-2.0x, and it should also allow for better scaling due to the reduced cache load.